### PR TITLE
Add non-persistent live chat to instrument page

### DIFF
--- a/internal/app/pslive/client/globals.go
+++ b/internal/app/pslive/client/globals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sargassum-world/fluitans/pkg/godest/turbostreams"
 
 	"github.com/sargassum-world/pslive/internal/app/pslive/conf"
+	"github.com/sargassum-world/pslive/internal/clients/chat"
 	"github.com/sargassum-world/pslive/internal/clients/instruments"
 	"github.com/sargassum-world/pslive/internal/clients/ory"
 	"github.com/sargassum-world/pslive/internal/clients/planktoscope"
@@ -31,6 +32,7 @@ type Globals struct {
 	Instruments   *instruments.Client
 	Planktoscopes map[string]*planktoscope.Client
 	Presence      *presence.Store
+	Chat          *chat.Store
 
 	Logger godest.Logger
 }
@@ -82,6 +84,7 @@ func NewGlobals(l godest.Logger) (g *Globals, err error) {
 		return nil, errors.Wrap(err, "couldn't set up planktoscope client")
 	}
 	g.Presence = presence.NewStore()
+	g.Chat = chat.NewStore()
 
 	g.Logger = l
 	return g, nil

--- a/internal/app/pslive/handling/chat.go
+++ b/internal/app/pslive/handling/chat.go
@@ -1,0 +1,72 @@
+package handling
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sargassum-world/fluitans/pkg/godest"
+	"github.com/sargassum-world/fluitans/pkg/godest/turbostreams"
+
+	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
+	"github.com/sargassum-world/pslive/internal/clients/ory"
+)
+
+const (
+	messagePartial = "shared/chat/message.partial.tmpl"
+	sendPartial    = "shared/chat/send.partial.tmpl"
+)
+
+func appendChatMessageStream(topic, userID, userIdentifier, message string) turbostreams.Message {
+	return turbostreams.Message{
+		Action:   turbostreams.ActionAppend,
+		Target:   topic + "/messages",
+		Template: messagePartial,
+		Data: map[string]interface{}{
+			"UserID":         userID,
+			"UserIdentifier": userIdentifier,
+			"Message":        message,
+		},
+	}
+}
+
+func replaceChatSendStream(topic string, a auth.Auth) turbostreams.Message {
+	return turbostreams.Message{
+		Action:   turbostreams.ActionReplace,
+		Target:   topic + "/send",
+		Template: sendPartial,
+		Data: map[string]interface{}{
+			"Topic": topic,
+			"Auth":  a,
+		},
+	}
+}
+
+func HandleChatMessagesPost(
+	r godest.TemplateRenderer, oc *ory.Client, tsh *turbostreams.MessagesHub,
+) auth.HTTPHandlerFunc {
+	sendT := sendPartial
+	r.MustHave(sendT)
+	return func(c echo.Context, a auth.Auth) error {
+		// Parse params
+		name := c.Param("name")
+		message := c.FormValue("message")
+		topic := strings.TrimSuffix(c.Request().URL.Path, "/messages")
+
+		// Run queries
+		user, err := oc.GetIdentifier(c.Request().Context(), a.Identity.User)
+		if err != nil {
+			return err
+		}
+		tsh.Broadcast(topic+"/messages", appendChatMessageStream(topic, a.Identity.User, user, message))
+
+		// Render Turbo Stream if accepted
+		if turbostreams.Accepted(c.Request().Header) {
+			message := replaceChatSendStream(topic, a)
+			return r.TurboStream(c.Response(), message)
+		}
+
+		// Redirect user
+		return c.Redirect(http.StatusSeeOther, "/instruments/"+name)
+	}
+}

--- a/internal/app/pslive/routes/instruments/routes.go
+++ b/internal/app/pslive/routes/instruments/routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
 	"github.com/sargassum-world/pslive/internal/app/pslive/handling"
+	"github.com/sargassum-world/pslive/internal/clients/chat"
 	"github.com/sargassum-world/pslive/internal/clients/instruments"
 	"github.com/sargassum-world/pslive/internal/clients/ory"
 	"github.com/sargassum-world/pslive/internal/clients/planktoscope"
@@ -24,11 +25,12 @@ type Handlers struct {
 	ic  *instruments.Client
 	pcs map[string]*planktoscope.Client
 	ps  *presence.Store
+	cs  *chat.Store
 }
 
 func New(
 	r godest.TemplateRenderer, oc *ory.Client, tsh *turbostreams.MessagesHub,
-	ic *instruments.Client, pcs map[string]*planktoscope.Client, ps *presence.Store,
+	ic *instruments.Client, pcs map[string]*planktoscope.Client, ps *presence.Store, cs *chat.Store,
 ) *Handlers {
 	return &Handlers{
 		r:   r,
@@ -37,6 +39,7 @@ func New(
 		ic:  ic,
 		pcs: pcs,
 		ps:  ps,
+		cs:  cs,
 	}
 }
 
@@ -58,6 +61,6 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss se
 	tsr.MSG("/instruments/:name/chat/messages", handling.HandleTSMsg(h.r, ss))
 	// TODO: make and use a middleware which checks to ensure the instrument exists
 	hr.POST("/instruments/:name/chat/messages", handling.HandleChatMessagesPost(
-		h.r, h.oc, h.tsh,
+		h.r, h.oc, h.tsh, h.cs,
 	), haz)
 }

--- a/internal/app/pslive/routes/instruments/routes.go
+++ b/internal/app/pslive/routes/instruments/routes.go
@@ -45,6 +45,7 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss se
 	haz := auth.RequireHTTPAuthz(ss)
 	hr.GET("/instruments", h.HandleInstrumentsGet())
 	hr.GET("/instruments/:name", h.HandleInstrumentGet())
+	// TODO: make and use a middleware which checks to ensure the instrument exists
 	tsr.SUB("/instruments/:name/users", handling.HandlePresenceSub(h.r, ss, h.oc, h.ps))
 	tsr.UNSUB("/instruments/:name/users", handling.HandlePresenceUnsub(h.r, ss, h.ps))
 	tsr.MSG("/instruments/:name/users", handling.HandleTSMsg(h.r, ss))
@@ -52,4 +53,11 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss se
 	tsr.PUB("/instruments/:name/controller/pump", h.HandlePumpPub())
 	tsr.MSG("/instruments/:name/controller/pump", handling.HandleTSMsg(h.r, ss))
 	hr.POST("/instruments/:name/controller/pump", h.HandlePumpPost(), haz)
+	// TODO: make and use a middleware which checks to ensure the instrument exists
+	tsr.SUB("/instruments/:name/chat/messages", turbostreams.EmptyHandler)
+	tsr.MSG("/instruments/:name/chat/messages", handling.HandleTSMsg(h.r, ss))
+	// TODO: make and use a middleware which checks to ensure the instrument exists
+	hr.POST("/instruments/:name/chat/messages", handling.HandleChatMessagesPost(
+		h.r, h.oc, h.tsh,
+	), haz)
 }

--- a/internal/app/pslive/routes/privatechat/routes.go
+++ b/internal/app/pslive/routes/privatechat/routes.go
@@ -1,5 +1,5 @@
-// Package users contains the route handlers related to users.
-package users
+// Package privatechat contains the route handlers related to private chats.
+package privatechat
 
 import (
 	"github.com/sargassum-world/fluitans/pkg/godest"
@@ -40,14 +40,17 @@ func New(
 func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss session.Store) {
 	hr := auth.NewHTTPRouter(er, ss)
 	haz := auth.RequireHTTPAuthz(ss)
-	hr.GET("/users", h.HandleUsersGet())
-	hr.GET("/users/:id", h.HandleUserGet())
-	// TODO: make and use a middleware which checks to ensure the user exists
-	tsr.SUB("/users/:id/chat/users", handling.HandlePresenceSub(h.r, ss, h.oc, h.ps))
-	tsr.UNSUB("/users/:id/chat/users", handling.HandlePresenceUnsub(h.r, ss, h.ps))
-	tsr.MSG("/users/:id/chat/users", handling.HandleTSMsg(h.r, ss))
-	tsr.SUB("/users/:id/chat/messages", turbostreams.EmptyHandler)
-	tsr.MSG("/users/:id/chat/messages", handling.HandleTSMsg(h.r, ss))
-	// TODO: make and use a middleware which checks to ensure the user exists
-	hr.POST("/users/:id/chat/messages", handling.HandleChatMessagesPost(h.r, h.oc, h.tsh, h.cs), haz)
+	tsaz := auth.RequireTSAuthz(ss)
+	// TODO: make and use a middleware which checks to ensure the users exist
+	tsr.SUB(
+		"/private-chats/:first/:second/chat/users", handling.HandlePresenceSub(h.r, ss, h.oc, h.ps),
+		tsaz, // FIXME: currently any authenticated user can subscribe!
+	)
+	tsr.UNSUB("/private-chats/:first/:second/chat/users", handling.HandlePresenceUnsub(h.r, ss, h.ps))
+	tsr.MSG("/private-chats/:first/:second/chat/users", handling.HandleTSMsg(h.r, ss))
+	tsr.SUB("/private-chats/:first/:second/chat/messages", turbostreams.EmptyHandler, tsaz)
+	tsr.MSG("/private-chats/:first/:second/chat/messages", handling.HandleTSMsg(h.r, ss))
+	hr.POST("/private-chats/:first/:second/chat/messages", handling.HandleChatMessagesPost(
+		h.r, h.oc, h.tsh, h.cs,
+	), haz) // FIXME: currently any authenticated user can send a message!
 }

--- a/internal/app/pslive/routes/routes.go
+++ b/internal/app/pslive/routes/routes.go
@@ -41,7 +41,8 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, em go
 	home.New(h.r).Register(er, ss)
 	auth.New(h.r, ss, oc, acc, ps, l).Register(er)
 	instruments.New(
-		h.r, oc, h.globals.TSBroker.Hub(), h.globals.Instruments, h.globals.Planktoscopes, ps,
+		h.r, oc, h.globals.TSBroker.Hub(), h.globals.Instruments, h.globals.Planktoscopes,
+		ps, h.globals.Chat,
 	).Register(er, tsr, ss)
 	users.New(h.r, oc).Register(er, ss)
 

--- a/internal/app/pslive/routes/routes.go
+++ b/internal/app/pslive/routes/routes.go
@@ -29,9 +29,11 @@ func New(r godest.TemplateRenderer, globals *client.Globals) *Handlers {
 func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, em godest.Embeds) {
 	ss := h.globals.Sessions
 	oc := h.globals.Ory
+	tsh := h.globals.TSBroker.Hub()
 	acc := h.globals.ACCancellers
 	l := h.globals.Logger
 	ps := h.globals.Presence
+	cs := h.globals.Chat
 
 	assets.RegisterStatic(er, em)
 	assets.NewTemplated(h.r).Register(er)
@@ -41,10 +43,9 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, em go
 	home.New(h.r).Register(er, ss)
 	auth.New(h.r, ss, oc, acc, ps, l).Register(er)
 	instruments.New(
-		h.r, oc, h.globals.TSBroker.Hub(), h.globals.Instruments, h.globals.Planktoscopes,
-		ps, h.globals.Chat,
+		h.r, oc, tsh, h.globals.Instruments, h.globals.Planktoscopes, ps, cs,
 	).Register(er, tsr, ss)
-	users.New(h.r, oc).Register(er, ss)
+	users.New(h.r, oc, tsh, ps, cs).Register(er, tsr, ss)
 
 	tsr.PUB("/*", turbostreams.EmptyHandler)
 	tsr.UNSUB("/*", turbostreams.EmptyHandler)

--- a/internal/app/pslive/routes/routes.go
+++ b/internal/app/pslive/routes/routes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sargassum-world/pslive/internal/app/pslive/routes/cable"
 	"github.com/sargassum-world/pslive/internal/app/pslive/routes/home"
 	"github.com/sargassum-world/pslive/internal/app/pslive/routes/instruments"
+	"github.com/sargassum-world/pslive/internal/app/pslive/routes/privatechat"
 	"github.com/sargassum-world/pslive/internal/app/pslive/routes/users"
 )
 
@@ -45,6 +46,7 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, em go
 	instruments.New(
 		h.r, oc, tsh, h.globals.Instruments, h.globals.Planktoscopes, ps, cs,
 	).Register(er, tsr, ss)
+	privatechat.New(h.r, oc, tsh, ps, cs).Register(er, tsr, ss)
 	users.New(h.r, oc, tsh, ps, cs).Register(er, tsr, ss)
 
 	tsr.PUB("/*", turbostreams.EmptyHandler)

--- a/internal/app/pslive/routes/users/routes.go
+++ b/internal/app/pslive/routes/users/routes.go
@@ -4,26 +4,50 @@ package users
 import (
 	"github.com/sargassum-world/fluitans/pkg/godest"
 	"github.com/sargassum-world/fluitans/pkg/godest/session"
+	"github.com/sargassum-world/fluitans/pkg/godest/turbostreams"
 
 	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
+	"github.com/sargassum-world/pslive/internal/app/pslive/handling"
+	"github.com/sargassum-world/pslive/internal/clients/chat"
 	"github.com/sargassum-world/pslive/internal/clients/ory"
+	"github.com/sargassum-world/pslive/internal/clients/presence"
 )
 
 type Handlers struct {
 	r godest.TemplateRenderer
 
 	oc *ory.Client
+
+	tsh *turbostreams.MessagesHub
+
+	ps *presence.Store
+	cs *chat.Store
 }
 
-func New(r godest.TemplateRenderer, oc *ory.Client) *Handlers {
+func New(
+	r godest.TemplateRenderer, oc *ory.Client, tsh *turbostreams.MessagesHub,
+	ps *presence.Store, cs *chat.Store,
+) *Handlers {
 	return &Handlers{
-		r:  r,
-		oc: oc,
+		r:   r,
+		oc:  oc,
+		tsh: tsh,
+		ps:  ps,
+		cs:  cs,
 	}
 }
 
-func (h *Handlers) Register(er godest.EchoRouter, ss session.Store) {
+func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss session.Store) {
 	hr := auth.NewHTTPRouter(er, ss)
+	haz := auth.RequireHTTPAuthz(ss)
 	hr.GET("/users", h.HandleUsersGet())
 	hr.GET("/users/:id", h.HandleUserGet())
+	// TODO: make and use a middleware which checks to ensure the user exists
+	tsr.SUB("/users/:id/chat/public/users", handling.HandlePresenceSub(h.r, ss, h.oc, h.ps))
+	tsr.UNSUB("/users/:id/chat/public/users", handling.HandlePresenceUnsub(h.r, ss, h.ps))
+	tsr.MSG("/users/:id/chat/public/users", handling.HandleTSMsg(h.r, ss))
+	tsr.SUB("/users/:id/chat/public/messages", turbostreams.EmptyHandler)
+	tsr.MSG("/users/:id/chat/public/messages", handling.HandleTSMsg(h.r, ss))
+	// TODO: make and use a middleware which checks to ensure the user exists
+	hr.POST("/users/:id/chat/public/messages", handling.HandleChatMessagesPost(h.r, h.oc, h.tsh, h.cs), haz)
 }

--- a/internal/app/pslive/routes/users/user.go
+++ b/internal/app/pslive/routes/users/user.go
@@ -12,26 +12,49 @@ import (
 )
 
 type UserData struct {
-	Identity               ory.Identity
-	PublicKnownViewers     []presence.User
-	PublicAnonymousViewers []string
-	PublicChatMessages     []chat.Message
+	Identity                ory.Identity
+	PublicKnownViewers      []presence.User
+	PublicAnonymousViewers  []string
+	PublicChatMessages      []chat.Message
+	PrivateKnownViewers     []presence.User
+	PrivateAnonymousViewers []string
+	PrivateChatMessages     []chat.Message
 }
 
 func getUserData(
-	ctx context.Context, id string, oc *ory.Client, ps *presence.Store, cs *chat.Store,
+	ctx context.Context, id string, a auth.Auth, oc *ory.Client, ps *presence.Store, cs *chat.Store,
 ) (*UserData, error) {
 	identity, err := oc.GetIdentity(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	publicKnown, publicAnonymous := ps.List("/users/" + id + "/chat/public/users")
-	publicMessages := cs.List("/users/" + id + "/chat/public/messages")
+
+	// Public chat
+	publicKnown, publicAnonymous := ps.List("/users/" + id + "/chat/users")
+	publicMessages := cs.List("/users/" + id + "/chat/messages")
+
+	// Private chat
+	var privateKnown []presence.User
+	var privateAnonymous []string
+	var privateMessages []chat.Message
+	if a.Identity.Authenticated && a.Identity.User != id {
+		first := id
+		second := a.Identity.User
+		if second < first {
+			first, second = second, first
+		}
+		privateKnown, privateAnonymous = ps.List("/private-chats/" + first + "/" + second + "/chat/users")
+		privateMessages = cs.List("/private-chats/" + first + "/" + second + "/chat/messages")
+	}
+
 	return &UserData{
-		Identity:               identity,
-		PublicKnownViewers:     publicKnown,
-		PublicAnonymousViewers: publicAnonymous,
-		PublicChatMessages:     publicMessages,
+		Identity:                identity,
+		PublicKnownViewers:      publicKnown,
+		PublicAnonymousViewers:  publicAnonymous,
+		PublicChatMessages:      publicMessages,
+		PrivateKnownViewers:     privateKnown,
+		PrivateAnonymousViewers: privateAnonymous,
+		PrivateChatMessages:     privateMessages,
 	}, nil
 }
 
@@ -43,7 +66,7 @@ func (h *Handlers) HandleUserGet() auth.HTTPHandlerFunc {
 		id := c.Param("id")
 
 		// Run queries
-		userData, err := getUserData(c.Request().Context(), id, h.oc, h.ps, h.cs)
+		userData, err := getUserData(c.Request().Context(), id, a, h.oc, h.ps, h.cs)
 		if err != nil {
 			return err
 		}

--- a/internal/clients/chat/store.go
+++ b/internal/clients/chat/store.go
@@ -1,0 +1,53 @@
+// Package chat provides a high-level store of chat messages
+package chat
+
+import (
+	"sync"
+	"time"
+)
+
+type Message struct {
+	Time             time.Time
+	SenderID         string
+	SenderIdentifier string
+	Text             string
+}
+
+const maxHistory = 100 // max number of messages to store per topic
+
+type Store struct {
+	messages map[string][]Message
+	mmu      sync.RWMutex
+}
+
+func NewStore() *Store {
+	return &Store{
+		messages: make(map[string][]Message),
+	}
+}
+
+func (s *Store) Add(topic string, m Message) {
+	// We could have less lock contention if we had more granular locks, but we don't care about such
+	// scalability yet.
+	s.mmu.Lock()
+	defer s.mmu.Unlock()
+
+	// It's extremely inefficient to use slices for a queue due to allocations/deallocations, but
+	// we aren't at a scale to care about this performance yet.
+	s.messages[topic] = append(s.messages[topic], m)
+	if len(s.messages[topic]) > maxHistory {
+		s.messages[topic] = s.messages[topic][len(s.messages[topic])-maxHistory:]
+	}
+}
+
+func (s *Store) List(topic string) []Message {
+	s.mmu.RLock()
+	defer s.mmu.RUnlock()
+
+	messages, ok := s.messages[topic]
+	if !ok {
+		return []Message{}
+	}
+
+	return messages
+}

--- a/internal/clients/presence/store.go
+++ b/internal/clients/presence/store.go
@@ -1,4 +1,4 @@
-// Package presence provides a high-level client for information about user presence on pages
+// Package presence provides a high-level store of information about user presence on pages
 package presence
 
 import (

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -36,7 +36,7 @@
     "@fontsource/atkinson-hyperlegible": "^4.5.1",
     "@fontsource/oxygen-mono": "^4.5.0",
     "@hotwired/turbo": "^7.0.1",
-    "@sargassum-world/stimulated": "^0.4.0",
+    "@sargassum-world/stimulated": "^0.4.1",
     "stimulus": "2.0.0"
   }
 }

--- a/web/app/src/main-deferred.js
+++ b/web/app/src/main-deferred.js
@@ -2,6 +2,8 @@ import {
   CSRFController,
   DefaultScrollableController,
   FormSubmissionController,
+  LoadFocusController,
+  LoadScrollController,
   NavigationLinkController,
   NavigationMenuController,
   ThemeController,
@@ -22,6 +24,8 @@ const Stimulus = Application.start();
 Stimulus.register('csrf', CSRFController);
 Stimulus.register('default-scrollable', DefaultScrollableController);
 Stimulus.register('form-submission', FormSubmissionController);
+Stimulus.register('load-focus', LoadFocusController);
+Stimulus.register('load-scroll', LoadScrollController);
 Stimulus.register('navigation-link', NavigationLinkController);
 Stimulus.register('navigation-menu', NavigationMenuController);
 Stimulus.register('theme', ThemeController);

--- a/web/app/src/styles/app/components/_all.scss
+++ b/web/app/src/styles/app/components/_all.scss
@@ -1,4 +1,6 @@
 @charset 'utf-8';
 
 @import 'styles/app/components/accordions.scss';
+@import 'styles/app/components/chat.scss';
+@import 'styles/app/components/instrument.scss';
 @import 'styles/app/components/turbo-progress.scss';

--- a/web/app/src/styles/app/components/chat.scss
+++ b/web/app/src/styles/app/components/chat.scss
@@ -1,0 +1,13 @@
+@charset 'utf-8';
+
+.chat-messages {
+  height: 26em;
+  overflow: auto;
+  margin-bottom: 0.5 * $gap;
+  margin-right: 0.5 * $gap;
+
+  @include from($navside-breakpoint) {
+    margin-bottom: $gap;
+    margin-right: $gap;
+  }
+}

--- a/web/app/src/styles/app/components/chat.scss
+++ b/web/app/src/styles/app/components/chat.scss
@@ -4,10 +4,15 @@
   height: 26em;
   overflow: auto;
   margin-bottom: 0.5 * $gap;
-  margin-right: 0.5 * $gap;
 
   @include from($navside-breakpoint) {
     margin-bottom: $gap;
-    margin-right: $gap;
+  }
+}
+
+.chat-message {
+  margin-top: 0.25 * $gap;
+  @include from($navside-breakpoint) {
+    margin-top: 0.5 * $gap;
   }
 }

--- a/web/app/src/styles/app/components/instrument.scss
+++ b/web/app/src/styles/app/components/instrument.scss
@@ -1,0 +1,9 @@
+@charset 'utf-8';
+
+.narrow-card {
+  max-width: 24em;
+}
+
+.wide-card {
+  max-width: 48em;
+}

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@eslint/eslintrc@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.1.tgz#8b5e1c49f4077235516bc9ec7d41378c0f69b8c6"
-  integrity sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==
+"@eslint/eslintrc@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.2.tgz#4989b9e8c0216747ee7cca314ae73791bb281aae"
+  integrity sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -39,9 +39,9 @@
     strip-json-comments "^3.1.1"
 
 "@fontsource/atkinson-hyperlegible@^4.5.1":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-4.5.6.tgz#6e709184b8a8a1e8db245e1af6b116499bc22bc2"
-  integrity sha512-DzRB7tcDCxJLxu5Wrs9SojnRBNc5Hwky9FPDLhfHjkvPMWQ8AaVPPPcsTOseY3RFmQmV21zjpmJZNWvLXckarw==
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-4.5.7.tgz#06dbc359362ed769a012a9202e35437a77e232f0"
+  integrity sha512-aceHefVY/tls5hcdOXfx81HWFAFD1VGqZRnKGBDc0cgdKAg6fx2qD0hd9eUSNGqtVmijmw1/KXFYxXS5Df6XxQ==
 
 "@fontsource/oxygen-mono@^4.5.0":
   version "4.5.6"
@@ -119,9 +119,9 @@
     resolve "^1.19.0"
 
 "@rollup/pluginutils@4":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.0.tgz#a14bbd058fdbba0a5647143b16ed0d86fb60bd08"
-  integrity sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
   dependencies:
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
@@ -135,10 +135,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sargassum-world/stimulated@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@sargassum-world/stimulated/-/stimulated-0.4.0.tgz#4a879311ce7847c2d08c9af37d6df88d90b9b5b5"
-  integrity sha512-olfeL7N91LIuJDwQCRvI7wd2SA+0+lKqFQ4Hdd3E8se1XP/jVWlng4/nmz9GDigWeOxo01Z2jG3GfQSh+JiIPQ==
+"@sargassum-world/stimulated@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@sargassum-world/stimulated/-/stimulated-0.4.1.tgz#772782b31cf002110f726c8ec0b6e61187d4f77f"
+  integrity sha512-dPkYC03XDEu/skKczK2S4mf/QObS7R0LBVeRI1D0dEt70yf0XtqWGB4UsBKO0pgfjvSfmGVSiRvU3wZvN6pw+w==
   dependencies:
     "@hotwired/turbo" "^7.0.1"
     "@rails/actioncable" "^6.1.5"
@@ -210,9 +210,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
-  version "17.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
-  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+  version "17.0.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.28.tgz#365761fe7de7c3cfe7a8df8722d6c450d8a78273"
+  integrity sha512-UYmIeBnB0On70dN1iGCinsL1qH5JmIEJwa+3KX0Xw4HQJ8KA16ULlyTCNmnzfyzj/BlxZKmZLqp4TYdssnov1w==
 
 "@types/pug@^2.0.4":
   version "2.0.6"
@@ -239,9 +239,9 @@ acorn-jsx@^5.3.1:
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^8.5.0, acorn@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
-  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -312,13 +312,14 @@ array-union@^2.1.0:
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array.prototype.flat@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13"
-  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
+  integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.19.0"
+    es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
 
 async-mutex@^0.3.2:
   version "0.3.2"
@@ -567,11 +568,12 @@ deepmerge@^4.2.2:
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
   dependencies:
-    object-keys "^1.0.12"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -606,10 +608,10 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.1:
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.2.tgz#8f7b696d8f15b167ae3640b4060670f3d054143f"
-  integrity sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==
+es-abstract@^1.19.1, es-abstract@^1.19.2:
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.5.tgz#a2cb01eb87f724e815b278b0dd0d00f36ca9a7f1"
+  integrity sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -622,7 +624,7 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     is-callable "^1.2.4"
     is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
-    is-shared-array-buffer "^1.0.1"
+    is-shared-array-buffer "^1.0.2"
     is-string "^1.0.7"
     is-weakref "^1.0.2"
     object-inspect "^1.12.0"
@@ -631,6 +633,13 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -722,11 +731,11 @@ eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.10.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.12.0.tgz#c7a5bd1cfa09079aae64c9076c07eada66a46e8e"
-  integrity sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.14.0.tgz#62741f159d9eb4a79695b28ec4989fcdec623239"
+  integrity sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==
   dependencies:
-    "@eslint/eslintrc" "^1.2.1"
+    "@eslint/eslintrc" "^1.2.2"
     "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
@@ -998,10 +1007,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-has-bigints@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
-  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+has-bigints@^1.0.1, has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1012,6 +1021,13 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
 
 has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
@@ -1120,9 +1136,9 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
 is-core-module@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
-  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
+  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
   dependencies:
     has "^1.0.3"
 
@@ -1199,7 +1215,7 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-shared-array-buffer@^1.0.1:
+is-shared-array-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
   integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
@@ -1319,6 +1335,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -1446,7 +1467,7 @@ object-inspect@^1.12.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -1594,9 +1615,9 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier-plugin-svelte@^2.4.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.6.0.tgz#0e845b560b55cd1d951d6c50431b4949f8591746"
-  integrity sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.7.0.tgz#ecfa4fe824238a4466a3497df1a96d15cf43cabb"
+  integrity sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==
 
 prettier@^2.4.1:
   version "2.6.2"
@@ -1777,9 +1798,9 @@ rollup-pluginutils@^2.3.3, rollup-pluginutils@^2.8.2:
     estree-walker "^0.6.1"
 
 rollup@^2.3.4:
-  version "2.70.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
-  integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
+  version "2.70.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.2.tgz#808d206a8851628a065097b7ba2053bd83ba0c0d"
+  integrity sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -1813,9 +1834,9 @@ sander@^0.5.0:
     rimraf "^2.5.2"
 
 sass@^1.43.2:
-  version "1.50.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.50.0.tgz#3e407e2ebc53b12f1e35ce45efb226ea6063c7c8"
-  integrity sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.51.0.tgz#25ea36cf819581fe1fe8329e8c3a4eaaf70d2845"
+  integrity sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -1925,10 +1946,17 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+source-map@~0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
+  integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
+  dependencies:
+    whatwg-url "^7.0.0"
 
 sourcemap-codec@^1.3.0, sourcemap-codec@^1.4.8:
   version "1.4.8"
@@ -2065,9 +2093,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svelte-check@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-2.5.0.tgz#510b5715dfa81f47e88dd2769cc52352b7728e7a"
-  integrity sha512-/laO032JQ1TpmYHgaaLndHNPeWW3VSL3liMB97sA9fYTEzlIy3jIo4Rgr7EzjNvieiNWG73C5voOAeNHlrwbpg==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-2.7.0.tgz#10d579dc89bf2e145a04786cc9fa8dabfb018a2a"
+  integrity sha512-GrvG24j0+i8AOm0k0KyJ6Dqc+TAR2yzB7rtS4nljHStunVxCTr/1KYlv4EsOeoqtHLzeWMOd5D2O6nDdP/yw4A==
   dependencies:
     chokidar "^3.4.1"
     fast-glob "^3.2.7"
@@ -2084,9 +2112,9 @@ svelte-dark-mode@^2.0.0:
   integrity sha512-/QmIqWGwzcfE82FAMuHBlKFwudW7Vcos60Ii8j/mJZ0H6kGAXwL5EGlcc8voBJMJv/i0QZmhp5b1ZX/XKg9NJQ==
 
 svelte-preprocess@^4.0.0:
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.5.tgz#c4d20fd67b92559e5cac80281154c813c1c17353"
-  integrity sha512-VKXPRScCzAZqeBZOGq4LLwtNrAu++mVn7XvQox3eFDV7Ciq0Lg70Q8QWjH9iXF7J+pMlXhPsSFwpCb2E+hoeyA==
+  version "4.10.6"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.6.tgz#5f9a53e7ed3b85fc7e0841120c725b76ac5a1ba8"
+  integrity sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==
   dependencies:
     "@types/pug" "^2.0.4"
     "@types/sass" "^1.16.0"
@@ -2096,18 +2124,18 @@ svelte-preprocess@^4.0.0:
     strip-indent "^3.0.0"
 
 svelte@^3.0.0:
-  version "3.46.6"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.6.tgz#23046a361ba5f8bafcc9cf9f6fca6d011fb005a7"
-  integrity sha512-o9nNft/OzCz/9kJpmWa1S52GAM+huCjPIsNWydYmgei74ZWlOA9/hN9+Z12INdklghu31seEXZMRHhS1+8DETw==
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.47.0.tgz#ba46fe4aea99fc650d6939c215cd4694f5325a19"
+  integrity sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==
 
 terser@^5.0.0:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
-  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.13.0.tgz#d43fd71861df1b4df743980caa257c6fa03acc44"
+  integrity sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==
   dependencies:
     acorn "^8.5.0"
     commander "^2.20.0"
-    source-map "~0.7.2"
+    source-map "~0.8.0-beta.0"
     source-map-support "~0.5.20"
 
 text-table@^0.2.0:
@@ -2122,6 +2150,13 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -2133,9 +2168,9 @@ tsconfig-paths@^3.14.1:
     strip-bom "^3.0.0"
 
 tslib@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2155,18 +2190,18 @@ typescript@*:
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 uglify-js@^3.0.6:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
-  integrity sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==
+  version "3.15.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.4.tgz#fa95c257e88f85614915b906204b9623d4fa340d"
+  integrity sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==
 
 unbox-primitive@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
-  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
   dependencies:
-    function-bind "^1.1.1"
-    has-bigints "^1.0.1"
-    has-symbols "^1.0.2"
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 universalify@^0.1.0:
@@ -2198,6 +2233,20 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-url@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
+  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/web/templates/instruments/instrument.page.tmpl
+++ b/web/templates/instruments/instrument.page.tmpl
@@ -30,22 +30,31 @@
             </a>
           {{end}}
         </p>
-        <h2>Video Stream</h2>
-        <img src="{{.Data.Instrument.MJPEGStream}}" crossorigin>
-        <h2>Controller</h2>
+        <h2>Microscope</h2>
+        <img src="{{.Data.Instrument.MJPEGStream}}" class="mr-4 mb-4" crossorigin>
         {{
           template "instruments/planktoscope/controller.partial.tmpl" dict
           "Instrument" .Data.Instrument
           "Controller" .Data.Controller
           "Auth" .Auth
         }}
-        <h2>Online Users</h2>
+        <h2>Live</h2>
+        <div class="card section-card">
+          <div class="card-content">
+            <h3>Users</h3>
+            {{
+              template "shared/presence/users.partial.tmpl" dict
+              "Topic" (print "/instruments/" .Data.Instrument.Name "/users")
+              "Known" .Data.KnownViewers
+              "Anonymous" .Data.AnonymousViewers
+              "WithTurboStreamSource" true
+            }}
+          </div>
+        </div>
         {{
-          template "shared/presence/users.partial.tmpl" dict
-          "Topic" (print "/instruments/" .Data.Instrument.Name "/users")
-          "Known" .Data.KnownViewers
-          "Anonymous" .Data.AnonymousViewers
-          "WithTurboStreamSource" true
+          template "shared/chat/box.partial.tmpl" dict
+          "Topic" (print "/instruments/" .Data.Instrument.Name "/chat")
+          "Auth" .Auth
         }}
       </turbo-frame>
     </section>

--- a/web/templates/instruments/instrument.page.tmpl
+++ b/web/templates/instruments/instrument.page.tmpl
@@ -36,12 +36,13 @@
       <div class="card section-card wide-card">
         <div class="card-content">
           <h3>Chat</h3>
-            {{
-              template "shared/chat/box.partial.tmpl" dict
-              "Topic" (print "/instruments/" .Data.Instrument.Name "/chat")
-              "Messages" .Data.ChatMessages
-              "Auth" .Auth
-            }}
+          {{
+            template "shared/chat/box.partial.tmpl" dict
+            "Topic" (print "/instruments/" .Data.Instrument.Name "/chat")
+            "Messages" .Data.ChatMessages
+            "Auth" .Auth
+            "IsPublic" true
+          }}
         </div>
       </div>
       <div class="card section-card wide-card">

--- a/web/templates/instruments/instrument.page.tmpl
+++ b/web/templates/instruments/instrument.page.tmpl
@@ -30,8 +30,10 @@
             </a>
           {{end}}
         </p>
-        <h2>Microscope</h2>
-        <img src="{{.Data.Instrument.MJPEGStream}}" class="mr-4 mb-4" crossorigin>
+        <h2>Controls</h2>
+        <div class="card section-card">
+          <img src="{{.Data.Instrument.MJPEGStream}}" crossorigin>
+        </div>
         {{
           template "instruments/planktoscope/controller.partial.tmpl" dict
           "Instrument" .Data.Instrument

--- a/web/templates/instruments/instrument.page.tmpl
+++ b/web/templates/instruments/instrument.page.tmpl
@@ -39,6 +39,7 @@
             {{
               template "shared/chat/box.partial.tmpl" dict
               "Topic" (print "/instruments/" .Data.Instrument.Name "/chat")
+              "Messages" .Data.ChatMessages
               "Auth" .Auth
             }}
         </div>

--- a/web/templates/instruments/instrument.page.tmpl
+++ b/web/templates/instruments/instrument.page.tmpl
@@ -30,35 +30,37 @@
             </a>
           {{end}}
         </p>
-        <h2>Controls</h2>
-        <div class="card section-card">
-          <img src="{{.Data.Instrument.MJPEGStream}}" crossorigin>
-        </div>
-        {{
-          template "instruments/planktoscope/controller.partial.tmpl" dict
-          "Instrument" .Data.Instrument
-          "Controller" .Data.Controller
-          "Auth" .Auth
-        }}
-        <h2>Live</h2>
-        <div class="card section-card">
-          <div class="card-content">
-            <h3>Users</h3>
+      <div class="section-card wide-card">
+        <img src="{{.Data.Instrument.MJPEGStream}}" crossorigin>
+      </div>
+      <div class="card section-card wide-card">
+        <div class="card-content">
+          <h3>Chat</h3>
             {{
-              template "shared/presence/users.partial.tmpl" dict
-              "Topic" (print "/instruments/" .Data.Instrument.Name "/users")
-              "Known" .Data.KnownViewers
-              "Anonymous" .Data.AnonymousViewers
-              "WithTurboStreamSource" true
+              template "shared/chat/box.partial.tmpl" dict
+              "Topic" (print "/instruments/" .Data.Instrument.Name "/chat")
+              "Auth" .Auth
             }}
-          </div>
         </div>
-        {{
-          template "shared/chat/box.partial.tmpl" dict
-          "Topic" (print "/instruments/" .Data.Instrument.Name "/chat")
-          "Auth" .Auth
-        }}
-      </turbo-frame>
+      </div>
+      <div class="card section-card wide-card">
+        <div class="card-content">
+          <h3>Users</h3>
+          {{
+            template "shared/presence/users.partial.tmpl" dict
+            "Topic" (print "/instruments/" .Data.Instrument.Name "/users")
+            "Known" .Data.KnownViewers
+            "Anonymous" .Data.AnonymousViewers
+            "WithTurboStreamSource" true
+          }}
+        </div>
+      </div>
+      {{
+        template "instruments/planktoscope/controller.partial.tmpl" dict
+        "Instrument" .Data.Instrument
+        "Controller" .Data.Controller
+        "Auth" .Auth
+      }}
     </section>
   </main>
 {{end}}

--- a/web/templates/instruments/planktoscope/pump.partial.tmpl
+++ b/web/templates/instruments/planktoscope/pump.partial.tmpl
@@ -11,7 +11,7 @@
   }}
 {{end}}
 <turbo-frame id="/instruments/{{$instrument.Name}}/controller/pump">
-  <div class="card section-card">
+  <div class="card section-card wide-card">
     <div class="card-content">
       <h3>
         Pump

--- a/web/templates/instruments/planktoscope/pump.partial.tmpl
+++ b/web/templates/instruments/planktoscope/pump.partial.tmpl
@@ -11,7 +11,7 @@
   }}
 {{end}}
 <turbo-frame id="/instruments/{{$instrument.Name}}/controller/pump">
-  <div class="card section-card is-block">
+  <div class="card section-card">
     <div class="card-content">
       <h3>
         Pump
@@ -129,7 +129,7 @@
                       value="Stop"
                       {{if and $pump.StateKnown (not $pump.Pumping)}}disabled{{end}}
                       data-form-submission-target="submit"
-                    >
+                    />
                   </div>
                   <div class="control">
                     <input
@@ -142,7 +142,7 @@
                         value="Start"
                       {{end}}
                       data-form-submission-target="submit"
-                    >
+                    />
                   </div>
                 </div>
               </div>

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -19,11 +19,11 @@
       <article class="message is-info chat-message">
         <div class="message-body">
           <p>
-            Welcome to the chat!
+            Welcome!
             {{if not $auth.Identity.Authenticated}}
-              Only logged-in users can send messages to the chat.
+              Only logged-in users can send messages to this chat.
             {{else if $isPublic}}
-              Please remember that anyone can view the chat, even people who are not logged in.
+              Please remember that anyone can view this chat, even people who are not logged in.
             {{end}}
           </p>
         </div>

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -10,6 +10,15 @@
         (print $topic "/messages")
       }}
       <turbo-frame id="{{print $topic "/messages"}}">
+        <p>
+          Welcome to the chat!
+          {{if not $auth.Identity.Authenticated}}
+            Only logged-in users can send messages to the chat.
+          {{else}}
+            Any message you send will be visible to everyone who was already on this page when you
+            sent the message, but not to anyone who opens this page afterwards.
+          {{end}}
+        </p>
       </turbo-frame>
       {{
         template "shared/chat/send.partial.tmpl" dict

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -8,15 +8,19 @@
   }}
   <div class="chat-messages">
     <turbo-frame id="{{print $topic "/messages"}}">
-      <p>
-        Welcome to the chat!
-        {{if not $auth.Identity.Authenticated}}
-          Only logged-in users can send messages to the chat.
-        {{else}}
-          Any message you send will be visible to everyone who was already on this page when you
-          sent the message, but not to anyone who opens this page afterwards.
-        {{end}}
-      </p>
+      <article class="message is-info">
+        <div class="message-body">
+          <p>
+            Welcome to the chat!
+            {{if not $auth.Identity.Authenticated}}
+              Only logged-in users can send messages to the chat.
+            {{else}}
+              Any message you send will be visible to everyone who was already on this page when you
+              sent the message, but not to anyone who opens this page afterwards.
+            {{end}}
+          </p>
+        </div>
+      </article>
     </turbo-frame>
   </div>
   {{

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -1,30 +1,27 @@
 {{$topic := (get . "Topic")}}
 {{$auth := (get . "Auth")}}
 
-<div class="card section-card">
-  <div class="card-content">
-    <h3>Chat</h3>
-    <turbo-frame id="{{$topic}}">
-      {{
-        template "shared/turbo-cable-stream-source.partial.tmpl"
-        (print $topic "/messages")
-      }}
-      <turbo-frame id="{{print $topic "/messages"}}">
-        <p>
-          Welcome to the chat!
-          {{if not $auth.Identity.Authenticated}}
-            Only logged-in users can send messages to the chat.
-          {{else}}
-            Any message you send will be visible to everyone who was already on this page when you
-            sent the message, but not to anyone who opens this page afterwards.
-          {{end}}
-        </p>
-      </turbo-frame>
-      {{
-        template "shared/chat/send.partial.tmpl" dict
-        "Topic" $topic
-        "Auth" $auth
-      }}
+<turbo-frame id="{{$topic}}">
+  {{
+    template "shared/turbo-cable-stream-source.partial.tmpl"
+    (print $topic "/messages")
+  }}
+  <div class="chat-messages">
+    <turbo-frame id="{{print $topic "/messages"}}">
+      <p>
+        Welcome to the chat!
+        {{if not $auth.Identity.Authenticated}}
+          Only logged-in users can send messages to the chat.
+        {{else}}
+          Any message you send will be visible to everyone who was already on this page when you
+          sent the message, but not to anyone who opens this page afterwards.
+        {{end}}
+      </p>
     </turbo-frame>
   </div>
-</div>
+  {{
+    template "shared/chat/send.partial.tmpl" dict
+    "Topic" $topic
+    "Auth" $auth
+  }}
+</turbo-frame>

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -1,0 +1,21 @@
+{{$topic := (get . "Topic")}}
+{{$auth := (get . "Auth")}}
+
+<div class="card section-card">
+  <div class="card-content">
+    <h3>Chat</h3>
+    <turbo-frame id="{{$topic}}">
+      {{
+        template "shared/turbo-cable-stream-source.partial.tmpl"
+        (print $topic "/messages")
+      }}
+      <turbo-frame id="{{print $topic "/messages"}}">
+      </turbo-frame>
+      {{
+        template "shared/chat/send.partial.tmpl" dict
+        "Topic" $topic
+        "Auth" $auth
+      }}
+    </turbo-frame>
+  </div>
+</div>

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -1,4 +1,5 @@
 {{$topic := (get . "Topic")}}
+{{$messages := (get . "Messages")}}
 {{$auth := (get . "Auth")}}
 
 <turbo-frame id="{{$topic}}">
@@ -8,15 +9,20 @@
   }}
   <div class="chat-messages">
     <turbo-frame id="{{print $topic "/messages"}}">
-      <article class="message is-info">
+      {{range $message := $messages}}
+        {{
+          template "shared/chat/message.partial.tmpl" dict
+          "Message" $message
+        }}
+      {{end}}
+      <article class="message is-info chat-message">
         <div class="message-body">
           <p>
             Welcome to the chat!
             {{if not $auth.Identity.Authenticated}}
               Only logged-in users can send messages to the chat.
             {{else}}
-              Any message you send will be visible to everyone who was already on this page when you
-              sent the message, but not to anyone who opens this page afterwards.
+              Please remember that anyone can view the chat, even people who are not logged in.
             {{end}}
           </p>
         </div>

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -1,6 +1,7 @@
 {{$topic := (get . "Topic")}}
 {{$messages := (get . "Messages")}}
 {{$auth := (get . "Auth")}}
+{{$isPublic := get . "IsPublic"}}
 
 <turbo-frame id="{{$topic}}">
   {{
@@ -21,7 +22,7 @@
             Welcome to the chat!
             {{if not $auth.Identity.Authenticated}}
               Only logged-in users can send messages to the chat.
-            {{else}}
+            {{else if $isPublic}}
               Please remember that anyone can view the chat, even people who are not logged in.
             {{end}}
           </p>

--- a/web/templates/shared/chat/message.partial.tmpl
+++ b/web/templates/shared/chat/message.partial.tmpl
@@ -3,7 +3,7 @@
 {{$userIdentifier := (get . "UserIdentifier")}}
 {{$message := (get . "Message")}}
 
-<div>
+<div class="chat-message" data-controller="load-scroll">
   <p class="has-text-weight-bold">
     [{{$time.Format "2006-01-02 15:04:05 MST"}}]
     <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>

--- a/web/templates/shared/chat/message.partial.tmpl
+++ b/web/templates/shared/chat/message.partial.tmpl
@@ -1,7 +1,10 @@
+{{$time := (get . "Time")}}
 {{$userID := (get . "UserID")}}
 {{$userIdentifier := (get . "UserIdentifier")}}
 {{$message := (get . "Message")}}
 
 <p>
-  <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>: {{$message}}
+  [{{$time.Format "2006-01-02 15:04:05 MST"}}]
+  <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>:
+  {{$message}}
 </p>

--- a/web/templates/shared/chat/message.partial.tmpl
+++ b/web/templates/shared/chat/message.partial.tmpl
@@ -3,8 +3,12 @@
 {{$userIdentifier := (get . "UserIdentifier")}}
 {{$message := (get . "Message")}}
 
-<p>
-  [{{$time.Format "2006-01-02 15:04:05 MST"}}]
-  <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>:
-  {{$message}}
-</p>
+<div>
+  <p class="has-text-weight-bold">
+    [{{$time.Format "2006-01-02 15:04:05 MST"}}]
+    <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>
+  </p>
+  <p>
+    {{$message}}
+  </p>
+</div>

--- a/web/templates/shared/chat/message.partial.tmpl
+++ b/web/templates/shared/chat/message.partial.tmpl
@@ -1,0 +1,7 @@
+{{$userID := (get . "UserID")}}
+{{$userIdentifier := (get . "UserIdentifier")}}
+{{$message := (get . "Message")}}
+
+<p>
+  <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>: {{$message}}
+</p>

--- a/web/templates/shared/chat/message.partial.tmpl
+++ b/web/templates/shared/chat/message.partial.tmpl
@@ -1,14 +1,9 @@
-{{$time := (get . "Time")}}
-{{$userID := (get . "UserID")}}
-{{$userIdentifier := (get . "UserIdentifier")}}
 {{$message := (get . "Message")}}
 
 <div class="chat-message" data-controller="load-scroll">
   <p class="has-text-weight-bold">
-    [{{$time.Format "2006-01-02 15:04:05 MST"}}]
-    <a href="/users/{{$userID}}" data-turbo="false">{{$userIdentifier}}</a>
+    [{{$message.Time.Format "2006-01-02 15:04:05 MST"}}]
+    <a href="/users/{{$message.SenderID}}" data-turbo="false">{{$message.SenderIdentifier}}</a>
   </p>
-  <p>
-    {{$message}}
-  </p>
+  <p>{{$message.Text}}</p>
 </div>

--- a/web/templates/shared/chat/send.partial.tmpl
+++ b/web/templates/shared/chat/send.partial.tmpl
@@ -1,0 +1,29 @@
+{{$topic := (get . "Topic")}}
+{{$auth := (get . "Auth")}}
+
+<turbo-frame id="{{print $topic "/send"}}">
+  {{if $auth.Identity.Authenticated}}
+    <form
+      action="{{print $topic "/messages"}}"
+      method="POST"
+      data-controller="form-submission csrf"
+      data-action="submit->form-submission#submit submit->csrf#addToken"
+    >
+      {{template "shared/auth/csrf-input.partial.tmpl" $auth.CSRF}}
+      <div class="field has-addons">
+        <div class="control">
+          <input type="text" class="input" name="message" size="100" />
+        </div>
+        <div class="control">
+          <input
+            class="button"
+            type="submit"
+            name="send"
+            value="Send"
+            data-form-submission-target="submit"
+          />
+        </div>
+      </div>
+    </form>
+  {{end}}
+</turbo-frame>

--- a/web/templates/shared/chat/send.partial.tmpl
+++ b/web/templates/shared/chat/send.partial.tmpl
@@ -12,7 +12,13 @@
       {{template "shared/auth/csrf-input.partial.tmpl" $auth.CSRF}}
       <div class="field has-addons">
         <div class="control">
-          <input type="text" class="input" name="message" size="100" />
+          <input
+            type="text"
+            class="input"
+            name="message"
+            size="100"
+            data-controller="load-focus"
+          />
         </div>
         <div class="control">
           <input

--- a/web/templates/shared/presence/users.partial.tmpl
+++ b/web/templates/shared/presence/users.partial.tmpl
@@ -12,12 +12,13 @@
       {{$user := index $known 0}}
       <p>1 authenticated user: <a href="/users/{{$user.ID}}">{{$user.Identifier}}</a></p>
     {{else}}
-      <p>{{len $known}} authenticated users:</p>
-      <ul>
-        {{range $user := $known}}
-          <li><a href="/users/{{$user.ID}}">{{$user.Identifier}}</a></li>
-        {{end}}
-      </ul>
+      <p>
+        {{len $known}} authenticated users:
+        {{range $i, $user := $known -}}
+          {{- if $i}},{{end}}
+          <a href="/users/{{$user.ID}}">{{$user.Identifier}}</a>
+        {{- end}}
+      </p>
     {{end}}
   {{end}}
 

--- a/web/templates/users/user.page.tmpl
+++ b/web/templates/users/user.page.tmpl
@@ -29,20 +29,46 @@
           <h3>Public Chat</h3>
           {{
             template "shared/presence/users.partial.tmpl" dict
-            "Topic" (print "/users/" .Data.Identity.Identifier "/chat/public/users")
+            "Topic" (print "/users/" .Data.Identity.ID "/chat/users")
             "Known" .Data.PublicKnownViewers
             "Anonymous" .Data.PublicAnonymousViewers
             "WithTurboStreamSource" true
           }}
           {{
             template "shared/chat/box.partial.tmpl" dict
-            "Topic" (print "/users/" .Data.Identity.ID "/chat/public")
+            "Topic" (print "/users/" .Data.Identity.ID "/chat")
             "Messages" .Data.PublicChatMessages
             "Auth" .Auth
             "IsPublic" true
           }}
         </div>
       </div>
+      {{if and .Auth.Identity.Authenticated (ne .Auth.Identity.User .Data.Identity.ID)}}
+        <div class="card section-card wide-card">
+          <div class="card-content">
+            <h3>Direct Chat</h3>
+            {{$first := .Data.Identity.ID}}
+            {{$second := .Auth.Identity.User}}
+            {{if lt $second $first }}
+              {{$first = .Auth.Identity.User}}
+              {{$second = .Data.Identity.ID}}
+            {{end}}
+            {{
+              template "shared/presence/users.partial.tmpl" dict
+              "Topic" (print "/private-chats/" $first "/" $second "/chat/users")
+              "Known" .Data.PrivateKnownViewers
+              "Anonymous" .Data.PrivateAnonymousViewers
+              "WithTurboStreamSource" true
+            }}
+            {{
+              template "shared/chat/box.partial.tmpl" dict
+              "Topic" (print "/private-chats/" $first "/" $second "/chat")
+              "Messages" .Data.PrivateChatMessages
+              "Auth" .Auth
+            }}
+          </div>
+        </div>
+      {{end}}
     </section>
   </main>
 {{end}}

--- a/web/templates/users/user.page.tmpl
+++ b/web/templates/users/user.page.tmpl
@@ -19,8 +19,30 @@
     <section class="section content">
       <h1>User {{.Data.Identity.Identifier}}</h1>
       <turbo-frame id="/users/{{.Data.Identity.Identifier}}/info">
-        <p>Email: {{.Data.Identity.Email}}</p>
+        {{if .Auth.Identity.Authenticated}}
+          <p>Email: {{.Data.Identity.Email}}</p>
+        {{end}}
       </turbo-frame>
+      <h2>Chat</h2>
+      <div class="card section-card wide-card">
+        <div class="card-content">
+          <h3>Public Chat</h3>
+          {{
+            template "shared/presence/users.partial.tmpl" dict
+            "Topic" (print "/users/" .Data.Identity.Identifier "/chat/public/users")
+            "Known" .Data.PublicKnownViewers
+            "Anonymous" .Data.PublicAnonymousViewers
+            "WithTurboStreamSource" true
+          }}
+          {{
+            template "shared/chat/box.partial.tmpl" dict
+            "Topic" (print "/users/" .Data.Identity.ID "/chat/public")
+            "Messages" .Data.PublicChatMessages
+            "Auth" .Auth
+            "IsPublic" true
+          }}
+        </div>
+      </div>
     </section>
   </main>
 {{end}}


### PR DESCRIPTION
This PR adds live chat boxes. Specifically:
- It adds a public chat to the instrument page. The 100 most recent chat messages per instrument are stored in memory for future page loads, while all messages sent will be live-broadcasted to all tabs/browsers with Action Cable support (i.e. with Javascript support) and scrolled into view. Browsers without Javascript support can just refresh the page or send a message to see an updated list of the 100 most recent messages. Only authenticated users can send messages, but everyone can view messages.
- It adds a public chat to the user page. This behaves the same way as the public chats for instruments.
- It adds a "direct chat" (i.e. private chat, though we don't have privacy guarantees) to the user page. This is a chat between the logged-in user and the user whose page they're viewing.