### PR TITLE
Make app installable as a PWA, cache static assets in service worker

### DIFF
--- a/internal/app/pslive/routes/assets/routes.go
+++ b/internal/app/pslive/routes/assets/routes.go
@@ -26,6 +26,7 @@ func NewTemplated(r godest.TemplateRenderer) *TemplatedHandlers {
 
 func (h *TemplatedHandlers) Register(er godest.EchoRouter) {
 	er.GET(AppURLPrefix+"app.webmanifest", h.getWebmanifest())
+	er.GET(AppURLPrefix+"offline", h.getOffline())
 }
 
 func RegisterStatic(er godest.EchoRouter, em godest.Embeds) {
@@ -35,6 +36,8 @@ func RegisterStatic(er godest.EchoRouter, em godest.Embeds) {
 		year = 365 * day
 	)
 
+	// TODO: serve sw.js with an ETag!
+	er.GET("/sw.js", echo.WrapHandler(godest.HandleFS("/", em.AppFS, week)))
 	er.GET("/favicon.ico", echo.WrapHandler(godest.HandleFS("/", em.StaticFS, week)))
 	er.GET(FontsURLPrefix+"*", echo.WrapHandler(godest.HandleFS(FontsURLPrefix, em.FontsFS, year)))
 	er.GET(

--- a/internal/app/pslive/routes/assets/templated.go
+++ b/internal/app/pslive/routes/assets/templated.go
@@ -4,6 +4,8 @@ package assets
 import (
 	"github.com/labstack/echo/v4"
 	"github.com/sargassum-world/fluitans/pkg/godest"
+
+	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
 )
 
 func (h *TemplatedHandlers) getWebmanifest() echo.HandlerFunc {
@@ -15,6 +17,19 @@ func (h *TemplatedHandlers) getWebmanifest() echo.HandlerFunc {
 		return h.r.CacheablePage(
 			c.Response(), c.Request(), t, struct{}{}, struct{}{},
 			godest.WithContentType("application/manifest+json; charset=UTF-8"),
+			godest.WithRevalidateWhenStale(cacheMaxAge),
+		)
+	}
+}
+
+func (h *TemplatedHandlers) getOffline() echo.HandlerFunc {
+	t := "app/offline.page.tmpl"
+	h.r.MustHave(t)
+	return func(c echo.Context) error {
+		const cacheMaxAge = 86400 // 1 day
+		// Produce output
+		return h.r.CacheablePage(
+			c.Response(), c.Request(), t, struct{}{}, auth.Auth{},
 			godest.WithRevalidateWhenStale(cacheMaxAge),
 		)
 	}

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
+    "@rollup/plugin-replace": "^4.0.0",
     "@sargassum-world/styles": "^0.2.0",
     "bulma": "^0.9.3",
     "eslint": "^8.10.0",
@@ -37,6 +38,10 @@
     "@fontsource/oxygen-mono": "^4.5.0",
     "@hotwired/turbo": "^7.0.1",
     "@sargassum-world/stimulated": "^0.4.1",
-    "stimulus": "2.0.0"
+    "stimulus": "2.0.0",
+    "workbox-expiration": "^6.5.3",
+    "workbox-recipes": "^6.5.3",
+    "workbox-routing": "^6.5.3",
+    "workbox-strategies": "^6.5.3"
   }
 }

--- a/web/app/src/main-deferred.js
+++ b/web/app/src/main-deferred.js
@@ -31,4 +31,8 @@ Stimulus.register('navigation-menu', NavigationMenuController);
 Stimulus.register('theme', ThemeController);
 Stimulus.register('turbo-cache', TurboCacheController);
 
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js');
+}
+
 export {};

--- a/web/app/src/sw.js
+++ b/web/app/src/sw.js
@@ -1,0 +1,62 @@
+import {
+  offlineFallback,
+  staticResourceCache,
+  warmStrategyCache,
+} from 'workbox-recipes';
+import { registerRoute, setDefaultHandler } from 'workbox-routing';
+import { CacheFirst, NetworkOnly } from 'workbox-strategies';
+import { ExpirationPlugin } from 'workbox-expiration';
+
+const cacheFirst = new CacheFirst();
+
+// Static assets (served with file-rev, so cache forever)
+
+staticResourceCache();
+registerRoute(/static\/.*/, cacheFirst);
+registerRoute(/app\/.*/, cacheFirst);
+
+// Favicon (served with max-age cache-control header)
+
+const faviconCacheFirst = new CacheFirst({
+  cacheName: 'favicon-cache',
+  plugins: [
+    new ExpirationPlugin({
+      maxAgeSeconds: 7 * 24 * 60 * 60,
+    }),
+  ],
+})
+warmStrategyCache({
+  urls: ['/favicon.ico'],
+  strategy: faviconCacheFirst,
+});
+registerRoute(/favicon\.ico/, faviconCacheFirst);
+
+// Fonts (served with max-age cache-control header)
+
+const fontCacheFirst = new CacheFirst({
+  cacheName: 'font-cache',
+  plugins: [
+    new ExpirationPlugin({
+      maxAgeSeconds: 365 * 24 * 60 * 60,
+    }),
+  ],
+})
+warmStrategyCache({
+  urls: [
+    '/fonts/atkinson-hyperlegible-latin-400-normal.woff2',
+    '/fonts/atkinson-hyperlegible-latin-700-normal.woff2',
+  ],
+  strategy: fontCacheFirst,
+})
+registerRoute(/fonts\/.*/, fontCacheFirst);
+
+// Pages (no cache)
+
+setDefaultHandler(new NetworkOnly());
+warmStrategyCache({
+  urls: ['/app/offline'],
+  strategy: cacheFirst,
+});
+offlineFallback({
+  pageFallback: '/app/offline',
+});

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -118,6 +118,14 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
+"@rollup/plugin-replace@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz#e34c457d6a285f0213359740b43f39d969b38a67"
+  integrity sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
 "@rollup/pluginutils@4":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
@@ -1052,6 +1060,11 @@ hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
+idb@^6.1.4:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-6.1.5.tgz#dbc53e7adf1ac7c59f9b2bf56e00b4ea4fce8c7b"
+  integrity sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw==
 
 ignore@^5.1.1, ignore@^5.2.0:
   version "5.2.0"
@@ -2282,6 +2295,61 @@ word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+workbox-cacheable-response@6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-6.5.3.tgz#b1f8c2bc599a7be8f7e3c262535629c558738e47"
+  integrity sha512-6JE/Zm05hNasHzzAGKDkqqgYtZZL2H06ic2GxuRLStA4S/rHUfm2mnLFFXuHAaGR1XuuYyVCEey1M6H3PdZ7SQ==
+  dependencies:
+    workbox-core "6.5.3"
+
+workbox-core@6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-6.5.3.tgz#bca038a9ef0d7a634a6db2a60f45313ed22ac249"
+  integrity sha512-Bb9ey5n/M9x+l3fBTlLpHt9ASTzgSGj6vxni7pY72ilB/Pb3XtN+cZ9yueboVhD5+9cNQrC9n/E1fSrqWsUz7Q==
+
+workbox-expiration@6.5.3, workbox-expiration@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-6.5.3.tgz#efc0811f371a2ede1052b9de1c4f072b71d50503"
+  integrity sha512-jzYopYR1zD04ZMdlbn/R2Ik6ixiXbi15c9iX5H8CTi6RPDz7uhvMLZPKEndZTpfgmUk8mdmT9Vx/AhbuCl5Sqw==
+  dependencies:
+    idb "^6.1.4"
+    workbox-core "6.5.3"
+
+workbox-precaching@6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-6.5.3.tgz#c870312b2ef901d790ab9e48da084e776c62af47"
+  integrity sha512-sjNfgNLSsRX5zcc63H/ar/hCf+T19fRtTqvWh795gdpghWb5xsfEkecXEvZ8biEi1QD7X/ljtHphdaPvXDygMQ==
+  dependencies:
+    workbox-core "6.5.3"
+    workbox-routing "6.5.3"
+    workbox-strategies "6.5.3"
+
+workbox-recipes@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-recipes/-/workbox-recipes-6.5.3.tgz#15beac9d8ae7a3a1c100218094a824b4dd3fd59a"
+  integrity sha512-IcgiKYmbGiDvvf3PMSEtmwqxwfQ5zwI7OZPio3GWu4PfehA8jI8JHI3KZj+PCfRiUPZhjQHJ3v1HbNs+SiSkig==
+  dependencies:
+    workbox-cacheable-response "6.5.3"
+    workbox-core "6.5.3"
+    workbox-expiration "6.5.3"
+    workbox-precaching "6.5.3"
+    workbox-routing "6.5.3"
+    workbox-strategies "6.5.3"
+
+workbox-routing@6.5.3, workbox-routing@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-6.5.3.tgz#a0a699d8cc90b5692bd3df24679acbbda3913777"
+  integrity sha512-DFjxcuRAJjjt4T34RbMm3MCn+xnd36UT/2RfPRfa8VWJGItGJIn7tG+GwVTdHmvE54i/QmVTJepyAGWtoLPTmg==
+  dependencies:
+    workbox-core "6.5.3"
+
+workbox-strategies@6.5.3, workbox-strategies@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-6.5.3.tgz#4bea9a48fee16cf43766e0d8138296773c8a9783"
+  integrity sha512-MgmGRrDVXs7rtSCcetZgkSZyMpRGw8HqL2aguszOc3nUmzGZsT238z/NN9ZouCxSzDu3PQ3ZSKmovAacaIhu1w==
+  dependencies:
+    workbox-core "6.5.3"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"

--- a/web/templates/app/app.webmanifest.tmpl
+++ b/web/templates/app/app.webmanifest.tmpl
@@ -1,11 +1,11 @@
 {
-  "name": "Planktoscope Live",
-  "description": "Livestreams from Planktoscopes.",
+  "name": "PlanktoScope Live",
+  "description": "Livestreams from PlanktoScope instruments.",
   "categories": ["utilities"],
-  "short_name": "PSLive",
   "lang": "en-US",
-  "display": "minimal-ui",
-  "start_url": ".",
+  "display": "standalone",
+  "scope": "/",
+  "start_url": "/",
   "background_color": "#151d28",
   "theme_color": "#00d1b2",
   "icons": [

--- a/web/templates/app/offline.page.tmpl
+++ b/web/templates/app/offline.page.tmpl
@@ -1,0 +1,16 @@
+{{template "shared/base.layout.tmpl" .}}
+
+{{define "title"}}You're not connected{{end}}
+{{define "description"}}This page can only be viewed with an internet connection.{{end}}
+
+{{define "content"}}
+  <main class="main-container">
+    <section class="section content">
+      <h1>Try again later</h1>
+      <p>
+        It looks like you don't have an internet connection right now. Unfortunately, this page
+        can only be viewed with an internet connection.
+      </p>
+    </section>
+  </main>
+{{end}}

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -1,12 +1,12 @@
 {{template "shared/base.layout.tmpl" .}}
 
 {{define "title"}}Home{{end}}
-{{define "description"}}Livestreams from Planktoscopes{{end}}
+{{define "description"}}Livestreams from PlanktoScope instruments{{end}}
 
 {{define "content"}}
   <main class="main-container">
     <section class="section content">
-      <h1>Planktoscope Live</h1>
+      <h1>PlanktoScope Live</h1>
       <p>Welcome!</p>
     </section>
   </main>

--- a/web/templates/shared/base.layout.tmpl
+++ b/web/templates/shared/base.layout.tmpl
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#00d1b2">
   <meta name="action-cable-url" content="/cable">
 
-  <title>{{block "title" .}}{{end}} | Planktoscope Live</title>
+  <title>{{block "title" .}}{{end}} | PlanktoScope Live</title>
 
   <style type="text/css">{{.Inlines.CSS.BundleEager}}</style>
   <noscript><link rel="stylesheet" href="{{appHashed "theme-light.min.css"}}"></noscript>


### PR DESCRIPTION
This PR registers a service worker in order to:
- Make the app installable as a Progressive Web App.
- Cache static assets (CSS bundles, JS bundles, fonts, static images, the webmanifest and the favicon) so that they're even accessible from a browser without an internet connection. This also has the benefit of avoiding two unnecessary 304'ed requests (for the webmanifest and an icon linked from the webmanifest) with each page load.
- Display an offline fallback page when any page in the app is opened without an internet connection. This is a nicer-looking replacement for the web browser's own "no internet" error page, and it's needed in order to make the app installable as a PWA.