### PR TITLE
Fix problem with CSP for service worker fetches

### DIFF
--- a/internal/app/pslive/server.go
+++ b/internal/app/pslive/server.go
@@ -90,6 +90,9 @@ func (s *Server) configureHeaders(e *echo.Echo) {
 			), " "),
 		),
 		"object-src 'none'",
+		// Needed for the service worker to be able to fetch camera streams, csrf, etc. from localhost
+		// or proper domains
+		"connect-src *",
 		"child-src 'self'",
 		"img-src *",
 		"base-uri 'none'",

--- a/web/app/src/styles/app/components/instrument.scss
+++ b/web/app/src/styles/app/components/instrument.scss
@@ -12,3 +12,7 @@
   width: 100%;
   height: auto;
 }
+
+.instrument-description {
+  white-space: pre-wrap;
+}

--- a/web/app/src/sw.js
+++ b/web/app/src/sw.js
@@ -21,7 +21,7 @@ const faviconCacheFirst = new CacheFirst({
   cacheName: 'favicon-cache',
   plugins: [
     new ExpirationPlugin({
-      maxAgeSeconds: 7 * 24 * 60 * 60,
+      maxAgeSeconds: 1 * 24 * 60 * 60,
     }),
   ],
 })
@@ -37,7 +37,7 @@ const fontCacheFirst = new CacheFirst({
   cacheName: 'font-cache',
   plugins: [
     new ExpirationPlugin({
-      maxAgeSeconds: 365 * 24 * 60 * 60,
+      maxAgeSeconds: 90 * 24 * 60 * 60,
     }),
   ],
 })

--- a/web/templates/app/app.webmanifest.tmpl
+++ b/web/templates/app/app.webmanifest.tmpl
@@ -7,7 +7,7 @@
   "scope": "/",
   "start_url": "/",
   "background_color": "#151d28",
-  "theme_color": "#00d1b2",
+  "theme_color": "#556b2f",
   "icons": [
     {
       "type": "image/png",

--- a/web/templates/instruments/instrument-basics.partial.tmpl
+++ b/web/templates/instruments/instrument-basics.partial.tmpl
@@ -55,7 +55,9 @@
       </div>
     </form>
   {{else}}
-    <p>{{$instrument.Description}}</p>
+    <p class="instrument-description">
+      {{- $instrument.Description -}}
+    </p>
   {{end}}
 
 </turbo-frame>


### PR DESCRIPTION
This PR fixes an issue with CSPs introduced by #43: the service worker was unable to fetch MJPEG streams from other origins, because no `connect-src` rule was defined; now a rule is defined to allow it to fetch from anywhere (though the resources it fetches are still checked by the browser for compliance with the other CSP rules).

Additionally, this PR fixes a bug where instrument description was only rendered with correct whitespace and newlines in the editing textarea for the instrument administrator; now, it's also rendered correctly for everyone else.