### PR TITLE
Fix bugs in with retrieving instrument controllers

### DIFF
--- a/internal/app/pslive/routes/instruments/planktoscope.go
+++ b/internal/app/pslive/routes/instruments/planktoscope.go
@@ -94,10 +94,10 @@ func (h *Handlers) HandlePumpPub() turbostreams.HandlerFunc {
 		if err != nil {
 			return err
 		}
-		pc, ok := h.pco.Get(id)
+		pc, ok := h.pco.Get(controllerID)
 		if !ok {
 			return errors.Errorf(
-				"planktoscope client for controller %d on instrument %d not found", id, controllerID,
+				"planktoscope client for controller %d on instrument %d not found", controllerID, id,
 			)
 		}
 

--- a/internal/clients/planktoscope/orchestrator.go
+++ b/internal/clients/planktoscope/orchestrator.go
@@ -39,9 +39,9 @@ func (o *Orchestrator) Add(id int64, url string) error {
 	}
 
 	o.planktoscopesMu.Lock()
-	defer o.planktoscopesMu.Unlock()
-
 	o.planktoscopes[id] = client
+	o.planktoscopesMu.Unlock()
+
 	go func() {
 		// FIXME: does this goroutine get leaked when a connection cannot be established? Or does
 		// Disconnect cancel the Connect method's infinite loop?

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -37,7 +37,7 @@
     "@fontsource/atkinson-hyperlegible": "^4.5.1",
     "@fontsource/oxygen-mono": "^4.5.0",
     "@hotwired/turbo": "^7.0.1",
-    "@sargassum-world/stimulated": "^0.4.1",
+    "@sargassum-world/stimulated": "^0.4.2",
     "stimulus": "2.0.0",
     "workbox-expiration": "^6.5.3",
     "workbox-recipes": "^6.5.3",

--- a/web/app/src/main-deferred.js
+++ b/web/app/src/main-deferred.js
@@ -2,6 +2,7 @@ import {
   CSRFController,
   DefaultScrollableController,
   FormSubmissionController,
+  HideableController,
   LoadFocusController,
   LoadScrollController,
   NavigationLinkController,
@@ -24,6 +25,7 @@ const Stimulus = Application.start();
 Stimulus.register('csrf', CSRFController);
 Stimulus.register('default-scrollable', DefaultScrollableController);
 Stimulus.register('form-submission', FormSubmissionController);
+Stimulus.register('hideable', HideableController);
 Stimulus.register('load-focus', LoadFocusController);
 Stimulus.register('load-scroll', LoadScrollController);
 Stimulus.register('navigation-link', NavigationLinkController);

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -143,10 +143,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sargassum-world/stimulated@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@sargassum-world/stimulated/-/stimulated-0.4.1.tgz#772782b31cf002110f726c8ec0b6e61187d4f77f"
-  integrity sha512-dPkYC03XDEu/skKczK2S4mf/QObS7R0LBVeRI1D0dEt70yf0XtqWGB4UsBKO0pgfjvSfmGVSiRvU3wZvN6pw+w==
+"@sargassum-world/stimulated@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@sargassum-world/stimulated/-/stimulated-0.4.2.tgz#316ec66e93b58cabb1b6ae5996f79f27f5c4ced5"
+  integrity sha512-FLqzNnz2hjo1dfvIppQGkin4Jke0+RIax1tB4+RCkAzzF0b6Wp6PeIKanztheg2jlIerjFM5k4HCaAaqV+ZAjA==
   dependencies:
     "@hotwired/turbo" "^7.0.1"
     "@rails/actioncable" "^6.1.5"

--- a/web/templates/app/app.webmanifest.tmpl
+++ b/web/templates/app/app.webmanifest.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "PlanktoScope Live",
   "description": "Livestreams from PlanktoScope instruments.",
-  "categories": ["utilities"],
+  "categories": ["social", "education"],
   "lang": "en-US",
   "display": "standalone",
   "scope": "/",

--- a/web/templates/shared/base.layout.tmpl
+++ b/web/templates/shared/base.layout.tmpl
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="description" content="{{block "description" .}}{{end}}">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="theme-color" content="#00d1b2">
+  <meta name="theme-color" content="#556b2f">
   <meta name="action-cable-url" content="/cable">
 
   <title>{{block "title" .}}{{end}} | PlanktoScope Live</title>

--- a/web/templates/shared/chat/box.partial.tmpl
+++ b/web/templates/shared/chat/box.partial.tmpl
@@ -16,7 +16,10 @@
           "Message" $message
         }}
       {{end}}
-      <article class="message is-info chat-message" data-controller="load-scroll">
+      <article
+        class="message is-info chat-message"
+        data-controller="load-scroll hideable"
+      >
         <div class="message-body">
           <p>
             Welcome!
@@ -26,6 +29,15 @@
               Please remember that anyone can view this chat, even people who are not logged in.
             {{end}}
           </p>
+          <div class="buttons is-padded">
+            <button
+              class="button is-primary is-hidden"
+              data-hideable-target="hider"
+              data-action="click->hideable#hide"
+            >
+              Ok
+            </button>
+          </div>
         </div>
       </article>
       <noscript>

--- a/web/templates/shared/instruments/instruments-list.partial.tmpl
+++ b/web/templates/shared/instruments/instruments-list.partial.tmpl
@@ -18,7 +18,7 @@
           {{- else -}}
             {{$instrument.Name -}}
           {{- end -}}
-        </a>: {{$instrument.Description}}
+        </a>: {{index (splitList "\n" $instrument.Description) 0}}
         <!-- TODO: show these as network entity cards instead -->
       </li>
     {{else}}


### PR DESCRIPTION
This PR fixes two previous bugs with retrieval of planktoscope controllers when viewing an instrument page, where an instrument with an invalid controller URL would always return HTTP 500 (related to mutex unlocking), and where an instrument even with a valid controller URL would return HTTP 500 (due to erroneous use of instrument ID for looking up controller ID).

This PR makes a few minor UI improvements:
- The list of instruments only shows the first line of an instrument description, to avoid weird rendering of multi-line instrument descriptions.
- The planktoscope MQTT client is more terse about reconnecting to MQTT brokers - now it only logs a warning once after each disconnection, rather than logging a warning every 30 sec. This is to avoid spamming the log with reconnection warnings.
- The chat welcome message now has a button (only visible with Javascript) to dismiss the welcome message. Welcome message dismissal is not persisted/propagated though, so it'll return with a refresh. One thing we could do is to persist dismissal states in client localStorage, but that adds complexity we don't need for now.