### PR TITLE
Rename SQL columns to allow for organizational identities, not just users

### DIFF
--- a/db/embeds.go
+++ b/db/embeds.go
@@ -24,6 +24,8 @@ var DomainEmbeds map[string]database.DomainEmbeds = map[string]database.DomainEm
 var MigrationFiles []database.MigrationFile = []database.MigrationFile{
 	{Domain: "chat", File: chat.MigrationFiles[0]},
 	{Domain: "instruments", File: instruments.MigrationFiles[0]},
+	{Domain: "chat", File: chat.MigrationFiles[1]},
+	{Domain: "instruments", File: instruments.MigrationFiles[1]},
 }
 
 // Queries

--- a/internal/app/pslive/routes/instruments/instrument.go
+++ b/internal/app/pslive/routes/instruments/instrument.go
@@ -253,7 +253,7 @@ func handleInstrumentComponentPost(
 			protocol := c.FormValue("protocol")
 			url := c.FormValue("url")
 			// FIXME: needs authorization check!
-			if err = componentUpdater(ctx, id, url, protocol); err != nil {
+			if err = componentUpdater(ctx, componentID, url, protocol); err != nil {
 				return err
 			}
 			// TODO: deal with turbo streams

--- a/internal/clients/chat/embeds.go
+++ b/internal/clients/chat/embeds.go
@@ -17,6 +17,7 @@ var (
 
 var MigrationFiles []string = []string{
 	"1-initialize-schema-v0.1.7",
+	"2-rename-user-to-identity-v0.1.10",
 }
 
 // Embeds

--- a/internal/clients/chat/insert-message.sql
+++ b/internal/clients/chat/insert-message.sql
@@ -1,2 +1,2 @@
-insert into chat_message (topic, send_time, sender_user_id, body)
+insert into chat_message (topic, send_time, sender_identity_id, body)
 values ($topic, $send_time, $sender_id, $body);

--- a/internal/clients/chat/migrations/2-rename-user-to-identity-v0.1.10.down.sql
+++ b/internal/clients/chat/migrations/2-rename-user-to-identity-v0.1.10.down.sql
@@ -1,0 +1,2 @@
+alter table chat_message
+rename column sender_identity_id to sender_user_id;

--- a/internal/clients/chat/migrations/2-rename-user-to-identity-v0.1.10.up.sql
+++ b/internal/clients/chat/migrations/2-rename-user-to-identity-v0.1.10.up.sql
@@ -1,0 +1,2 @@
+alter table chat_message
+rename column sender_user_id to sender_identity_id;

--- a/internal/clients/chat/select-messages-by-topic.sql
+++ b/internal/clients/chat/select-messages-by-topic.sql
@@ -1,10 +1,10 @@
 select * from (
   select
-    id             as id,
-    topic          as topic,
-    send_time      as send_time,
-    sender_user_id as sender_id,
-    body           as body
+    id                 as id,
+    topic              as topic,
+    send_time          as send_time,
+    sender_identity_id as sender_id,
+    body               as body
   from chat_message
   where
     chat_message.topic = $topic

--- a/internal/clients/instruments/embeds.go
+++ b/internal/clients/instruments/embeds.go
@@ -17,6 +17,7 @@ var (
 
 var MigrationFiles []string = []string{
 	"1-initialize-schema-v0.1.7",
+	"2-rename-user-to-identity-v0.1.10",
 }
 
 // Embeds

--- a/internal/clients/instruments/insert-instrument.sql
+++ b/internal/clients/instruments/insert-instrument.sql
@@ -1,2 +1,2 @@
-insert into instruments_instrument (name, description, admin_user_id)
+insert into instruments_instrument (name, description, admin_identity_id)
 values ($name, $description, $admin_id);

--- a/internal/clients/instruments/migrations/2-rename-user-to-identity-v0.1.10.down.sql
+++ b/internal/clients/instruments/migrations/2-rename-user-to-identity-v0.1.10.down.sql
@@ -1,0 +1,7 @@
+alter table instruments_instrument
+rename column admin_identity_id to admin_user_id;
+
+drop index instruments_instrument_idx_admin_identity_id;
+
+create index instruments_instrument_idx_admin_user_id
+on instruments_instrument (admin_user_id);

--- a/internal/clients/instruments/migrations/2-rename-user-to-identity-v0.1.10.up.sql
+++ b/internal/clients/instruments/migrations/2-rename-user-to-identity-v0.1.10.up.sql
@@ -1,0 +1,7 @@
+alter table instruments_instrument
+rename column admin_user_id to admin_identity_id;
+
+drop index instruments_instrument_idx_admin_user_id;
+
+create index instruments_instrument_idx_admin_identity_id
+on instruments_instrument (admin_identity_id);

--- a/internal/clients/instruments/select-instrument.sql
+++ b/internal/clients/instruments/select-instrument.sql
@@ -1,14 +1,14 @@
 select
-  i.id            as id,
-  i.name          as name,
-  i.description   as description,
-  i.admin_user_id as admin_id,
-  ca.id           as camera_id,
-  ca.url          as camera_url,
-  ca.protocol     as camera_protocol,
-  co.id           as controller_id,
-  co.url          as controller_url,
-  co.protocol     as controller_protocol
+  i.id                as id,
+  i.name              as name,
+  i.description       as description,
+  i.admin_identity_id as admin_id,
+  ca.id               as camera_id,
+  ca.url              as camera_url,
+  ca.protocol         as camera_protocol,
+  co.id               as controller_id,
+  co.url              as controller_url,
+  co.protocol         as controller_protocol
 from instruments_instrument as i
 left join instruments_camera as ca
   on i.id = ca.instrument_id

--- a/internal/clients/instruments/select-instruments-by-admin-id.sql
+++ b/internal/clients/instruments/select-instruments-by-admin-id.sql
@@ -1,18 +1,18 @@
 select
-  i.id            as id,
-  i.name          as name,
-  i.description   as description,
-  i.admin_user_id as admin_id,
-  ca.id           as camera_id,
-  ca.url          as camera_url,
-  ca.protocol     as camera_protocol,
-  co.id           as controller_id,
-  co.url          as controller_url,
-  co.protocol     as controller_protocol
+  i.id                as id,
+  i.name              as name,
+  i.description       as description,
+  i.admin_identity_id as admin_id,
+  ca.id               as camera_id,
+  ca.url              as camera_url,
+  ca.protocol         as camera_protocol,
+  co.id               as controller_id,
+  co.url              as controller_url,
+  co.protocol         as controller_protocol
 from instruments_instrument as i
 left join instruments_camera as ca
   on i.id = ca.instrument_id
 left join instruments_controller as co
   on i.id = co.instrument_id
 where
-  i.admin_user_id = $admin_id
+  i.admin_identity_id = $admin_id

--- a/internal/clients/instruments/select-instruments.sql
+++ b/internal/clients/instruments/select-instruments.sql
@@ -1,14 +1,14 @@
 select
-  i.id            as id,
-  i.name          as name,
-  i.description   as description,
-  i.admin_user_id as admin_id,
-  ca.id           as camera_id,
-  ca.url          as camera_url,
-  ca.protocol     as camera_protocol,
-  co.id           as controller_id,
-  co.url          as controller_url,
-  co.protocol     as controller_protocol
+  i.id                as id,
+  i.name              as name,
+  i.description       as description,
+  i.admin_identity_id as admin_id,
+  ca.id               as camera_id,
+  ca.url              as camera_url,
+  ca.protocol         as camera_protocol,
+  co.id               as controller_id,
+  co.url              as controller_url,
+  co.protocol         as controller_protocol
 from instruments_instrument as i
 left join instruments_camera as ca
   on i.id = ca.instrument_id


### PR DESCRIPTION
This PR adds migrations to rename the sqlite database columns for "user_id"s to "identity_id"s, so that organizational identities - and not just user identities - can (in the future) be used as IDs for chat message senders and instrument administrators.

This PR also fixes a bug where the wrong camera was being modified when one of multiple cameras were being modified, due to the use of the instrument ID rather than the camera ID for looking up the camera to modify.