### PR TITLE
Fix error handling in the camera stream

### DIFF
--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -163,7 +163,7 @@ func externalSourceFrameSender(
 			if err := handling.Except(
 				ss.SendFrame(frameError), context.Canceled, syscall.EPIPE,
 			); err != nil {
-				return false, errors.Wrap(err, "couldn't send mjpeg loading frame")
+				return false, errors.Wrap(err, "couldn't send mjpeg error frame")
 			}
 		}
 

--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -189,9 +189,7 @@ func externalSourceFrameSender(
 		// TODO: implement image resizing
 
 		// Send output
-		if err := handling.Except(
-			ss.SendFrame(frame), context.Canceled, syscall.EPIPE,
-		); err != nil {
+		if err := handling.Except(ss.SendFrame(frame), context.Canceled, syscall.EPIPE); err != nil {
 			return false, errors.Wrap(err, "couldn't send mjpeg frame")
 		}
 		return false, nil

--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -160,11 +160,12 @@ func externalSourceFrameSender(
 ) handling.Consumer[videostreams.Frame] {
 	return func(frame videostreams.Frame) (done bool, err error) {
 		if err = frame.Error(); err != nil {
-			if err := handling.Except(
+			if herr := handling.Except(
 				ss.SendFrame(frameError), context.Canceled, syscall.EPIPE,
-			); err != nil {
+			); herr != nil {
 				return false, errors.Wrap(err, "couldn't send mjpeg error frame")
 			}
+			return false, err
 		}
 
 		// Generate output

--- a/internal/app/pslive/routes/videostreams/proxied.go
+++ b/internal/app/pslive/routes/videostreams/proxied.go
@@ -167,12 +167,12 @@ func (h *Handlers) HandleExternalSourcePub() videostreams.HandlerFunc {
 		query, err := c.Query()
 		if err != nil {
 			err = errors.Wrap(err, "couldn't parse topic query params")
-			c.Publish(videostreams.NewErrorFrame(err))
+			c.Publish(mjpeg.NewErrorFrame(err))
 			return err
 		}
 		source, err := parseURLParam(query.Get("url"))
 		if err != nil {
-			c.Publish(videostreams.NewErrorFrame(err))
+			c.Publish(mjpeg.NewErrorFrame(err))
 			return err
 		}
 
@@ -181,7 +181,7 @@ func (h *Handlers) HandleExternalSourcePub() videostreams.HandlerFunc {
 		r, err := mjpeg.NewReceiverFromURL(ctx, h.hc, source)
 		if err != nil {
 			err = errors.Wrapf(err, "couldn't start mjpeg receiver for %s", source)
-			c.Publish(videostreams.NewErrorFrame(err))
+			c.Publish(mjpeg.NewErrorFrame(err))
 			return err
 		}
 		defer r.Close()

--- a/internal/clients/mjpeg/http-receiver.go
+++ b/internal/clients/mjpeg/http-receiver.go
@@ -26,6 +26,12 @@ type JPEGFrame struct {
 	err      error
 }
 
+func NewErrorFrame(err error) *JPEGFrame {
+	return &JPEGFrame{
+		err: err,
+	}
+}
+
 func (f *JPEGFrame) AsImage() (image.Image, videostreams.Operation, error) {
 	im, err := jpeg.Decode(bytes.NewReader(f.jpeg))
 	if err != nil {

--- a/internal/clients/videostreams/stream.go
+++ b/internal/clients/videostreams/stream.go
@@ -72,6 +72,9 @@ func (f *ImageFrame) AsImageFrame() (*ImageFrame, error) {
 }
 
 func (f *ImageFrame) AsJPEG() ([]byte, Operation, error) {
+	if f.Meta == nil {
+		return nil, Nop, errors.Errorf("unspecified jpeg quality due to missing metadata")
+	}
 	quality := f.Meta.Settings.JPEGEncodeQuality
 	if quality < 1 || quality > 100 {
 		return nil, Nop, errors.Errorf("invalid jpeg quality %d", quality)


### PR DESCRIPTION
Previously the GET handler for `/instruments/:id/cameras/:cameraID/stream.mjpeg` would segfault when the PUB handler for `video-streams/external-stream/source.mjpeg` emitted a `videostreams.ImageFrame` containing an error. This is because the GET handler would catch the error in the received frame, send an error-message image frame, and then continue to attempt to convert the received frame to a `mjpeg.JPEGFrame`. Now the GET handler returns early; and also the PUB handler `video-streams/external-stream/source.mjpeg` emits `mjpeg.JPEGFrame`s containing errors instead, to prevent the need for JPEG conversion.