### PR TITLE
Clean up some logging messages

### DIFF
--- a/internal/app/pslive/routes/videostreams/proxied.go
+++ b/internal/app/pslive/routes/videostreams/proxied.go
@@ -86,7 +86,6 @@ func externalSourceFrameSender(
 	l godest.Logger,
 ) handling.Consumer[videostreams.Frame] {
 	return func(frame videostreams.Frame) (done bool, err error) {
-		l.Debug("received frame from external source")
 		if err = frame.Error(); err != nil {
 			return false, errors.Wrapf(err, "error with video source")
 		}
@@ -113,7 +112,6 @@ func externalSourceFrameSender(
 		// TODO: implement image resizing
 
 		// Send output
-		l.Debug("sending frame from external source")
 		if err := handling.Except(
 			ss.SendFrame(frame), context.Canceled, syscall.EPIPE,
 		); err != nil {
@@ -196,7 +194,6 @@ func (h *Handlers) HandleExternalSourcePub() videostreams.HandlerFunc {
 		return handling.Except(
 			handling.Repeat(ctx, 0, func() (done bool, err error) {
 				// Load data
-				c.Logger().Debugf("receiving mjpeg frame from %s", source)
 				encodedFrame, err := r.Receive()
 				if errors.Is(err, io.EOF) {
 					c.Logger().Debugf("received eof from %s", source)
@@ -208,7 +205,6 @@ func (h *Handlers) HandleExternalSourcePub() videostreams.HandlerFunc {
 				}
 
 				// Publish data
-				c.Logger().Debugf("received and publishing frame from %s", source)
 				c.Publish(encodedFrame)
 				return false, nil
 			}),

--- a/internal/app/pslive/routes/videostreams/proxied.go
+++ b/internal/app/pslive/routes/videostreams/proxied.go
@@ -83,7 +83,6 @@ func (h *Handlers) HandleExternalSourceFrameGet() echo.HandlerFunc {
 func externalSourceFrameSender(
 	ss *mjpeg.StreamSender, annotated bool, quality int,
 	fpsCounter *ratecounter.RateCounter, fpsPeriod float32,
-	l godest.Logger,
 ) handling.Consumer[videostreams.Frame] {
 	return func(frame videostreams.Frame) (done bool, err error) {
 		if err = frame.Error(); err != nil {
@@ -154,7 +153,7 @@ func (h *Handlers) HandleExternalSourceStreamGet() echo.HandlerFunc {
 		const quality = 50 // TODO: implement adaptive quality for min FPS
 		if err := handling.Except(
 			handling.Consume(ctx, frameBuffer, externalSourceFrameSender(
-				ss, annotated, quality, fpsCounter, fpsPeriod, c.Logger(),
+				ss, annotated, quality, fpsCounter, fpsPeriod,
 			)),
 			context.Canceled,
 		); err != nil {

--- a/internal/app/pslive/routes/videostreams/proxied.go
+++ b/internal/app/pslive/routes/videostreams/proxied.go
@@ -12,7 +12,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/paulbellamy/ratecounter"
 	"github.com/pkg/errors"
-	"github.com/sargassum-world/godest"
 	"github.com/sargassum-world/godest/handling"
 
 	"github.com/sargassum-world/pslive/internal/clients/mjpeg"

--- a/internal/app/pslive/server.go
+++ b/internal/app/pslive/server.go
@@ -87,7 +87,7 @@ func (s *Server) configureLogging(e *echo.Echo) {
 	}))
 	e.HideBanner = true
 	e.HidePort = true
-	e.Logger.SetLevel(log.DEBUG) // TODO: set level via env var
+	e.Logger.SetLevel(log.INFO) // TODO: set level via env var
 }
 
 // turboDriveStyle is the stylesheet which Turbo Drive tries to install for its progress bar,


### PR DESCRIPTION
This PR removes some debug logging messages added by #211 which would have been printed on every video frame, because those messages did not help with troubleshooting #156.