### PR TITLE
Fix erroneous use of instrument IDs to lookup Planktoscope client

### DIFF
--- a/internal/app/pslive/auth/models.go
+++ b/internal/app/pslive/auth/models.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sargassum-world/godest/opa"
 	"github.com/sargassum-world/godest/session"
+
+	"github.com/sargassum-world/pslive/internal/clients/ory"
 )
 
 type Auth struct {
@@ -28,19 +30,18 @@ func RegisterGobTypes() {
 
 type Identity struct {
 	Authenticated bool
-	User          string
+	User          ory.IdentityID
 }
 
 func (i Identity) NewSubject() opa.Subject {
-	return opa.NewSubject(i.User, i.Authenticated)
+	return opa.NewSubject(string(i.User), i.Authenticated)
 }
 
-func SetIdentity(s *sessions.Session, username string) {
-	identity := Identity{
-		Authenticated: username != "",
-		User:          username,
+func SetIdentity(s *sessions.Session, id ory.IdentityID) {
+	s.Values["identity"] = Identity{
+		Authenticated: id != "",
+		User:          id,
 	}
-	s.Values["identity"] = identity
 }
 
 func GetIdentity(s sessions.Session) (identity Identity, err error) {

--- a/internal/app/pslive/routes/home/routes.go
+++ b/internal/app/pslive/routes/home/routes.go
@@ -42,8 +42,8 @@ func (h *Handlers) Register(er godest.EchoRouter, ss *session.Store) {
 
 type HomeViewData struct {
 	CameraInstruments []instruments.Instrument
-	AdminIdentifiers  map[string]string
-	PresenceCounts    map[int64]int
+	AdminIdentifiers  map[instruments.AdminID]ory.IdentityIdentifier
+	PresenceCounts    map[instruments.InstrumentID]int
 }
 
 func getHomeViewData(
@@ -60,19 +60,19 @@ func getHomeViewData(
 		}
 	}
 
-	vd.AdminIdentifiers = make(map[string]string)
+	vd.AdminIdentifiers = make(map[instruments.AdminID]ory.IdentityIdentifier)
 	for _, instrument := range vd.CameraInstruments {
 		if vd.AdminIdentifiers[instrument.AdminID], err = oc.GetIdentifier(
-			ctx, instrument.AdminID,
+			ctx, ory.IdentityID(instrument.AdminID),
 		); err != nil {
 			// TODO: log the error
 			continue
 		}
 	}
 
-	vd.PresenceCounts = make(map[int64]int)
+	vd.PresenceCounts = make(map[instruments.InstrumentID]int)
 	for _, instrument := range vd.CameraInstruments {
-		topic := fmt.Sprintf("/instruments/%d/users", instrument.ID)
+		topic := presence.Topic(fmt.Sprintf("/instruments/%d/users", instrument.ID))
 		vd.PresenceCounts[instrument.ID] = ps.Count(topic)
 	}
 

--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -129,7 +129,7 @@ func externalSourceFrameSender(
 func (h *Handlers) HandleInstrumentCameraPost() auth.HTTPHandlerFunc {
 	return handleInstrumentComponentPost(
 		"camera",
-		func(ctx context.Context, componentID int64, url, protocol string) error {
+		func(ctx context.Context, componentID instruments.CameraID, url, protocol string) error {
 			return h.is.UpdateCamera(ctx, instruments.Camera{
 				ID:       componentID,
 				URL:      url,
@@ -143,7 +143,7 @@ func (h *Handlers) HandleInstrumentCameraPost() auth.HTTPHandlerFunc {
 func (h *Handlers) HandleInstrumentCameraFrameGet() echo.HandlerFunc {
 	return func(c echo.Context) (err error) {
 		// Parse params
-		id, err := parseID(c.Param("cameraID"), "camera")
+		cameraID, err := parseID[instruments.CameraID](c.Param("cameraID"), "camera")
 		if err != nil {
 			return errors.Wrap(err, "couldn't parse camera ID path parameter")
 		}
@@ -159,9 +159,9 @@ func (h *Handlers) HandleInstrumentCameraFrameGet() echo.HandlerFunc {
 		}
 
 		// Run queries
-		camera, err := h.is.GetCamera(c.Request().Context(), id)
+		camera, err := h.is.GetCamera(c.Request().Context(), cameraID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("camera %d not found", id))
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("camera %d not found", cameraID))
 		}
 		sourceURL := camera.URL
 
@@ -199,7 +199,7 @@ func (h *Handlers) HandleInstrumentCameraStreamGet() echo.HandlerFunc {
 	jpegLoading := newErrorJPEG(errorWidth, errorHeight, "loading stream...")
 	return func(c echo.Context) error {
 		// Parse params
-		id, err := parseID(c.Param("cameraID"), "camera")
+		cameraID, err := parseID[instruments.CameraID](c.Param("cameraID"), "camera")
 		if err != nil {
 			return err
 		}
@@ -207,9 +207,9 @@ func (h *Handlers) HandleInstrumentCameraStreamGet() echo.HandlerFunc {
 		// TODO: implement a max framerate
 
 		// Run queries
-		camera, err := h.is.GetCamera(c.Request().Context(), id)
+		camera, err := h.is.GetCamera(c.Request().Context(), cameraID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("camera %d not found", id))
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("camera %d not found", cameraID))
 		}
 		sourceURL := camera.URL
 
@@ -253,7 +253,7 @@ func (h *Handlers) HandleInstrumentCameraStreamPub() videostreams.HandlerFunc {
 	frameLoading := newErrorFrame(errorWidth, errorHeight, "loading stream...")
 	return func(c *videostreams.Context) error {
 		// Parse params
-		id, err := parseID(c.Param("cameraID"), "camera")
+		cameraID, err := parseID[instruments.CameraID](c.Param("cameraID"), "camera")
 		if err != nil {
 			return err
 		}
@@ -261,9 +261,9 @@ func (h *Handlers) HandleInstrumentCameraStreamPub() videostreams.HandlerFunc {
 
 		// Run queries
 		ctx := c.Context()
-		camera, err := h.is.GetCamera(ctx, id)
+		camera, err := h.is.GetCamera(ctx, cameraID)
 		if err != nil {
-			return errors.Wrapf(err, "camera %d not found", id)
+			return errors.Wrapf(err, "camera %d not found", cameraID)
 		}
 		sourceURL := camera.URL
 

--- a/internal/app/pslive/routes/instruments/cameras.go
+++ b/internal/app/pslive/routes/instruments/cameras.go
@@ -9,7 +9,7 @@ import (
 
 func (h *Handlers) HandleInstrumentCamerasPost() auth.HTTPHandlerFunc {
 	return handleInstrumentComponentsPost(
-		func(ctx context.Context, id int64, url, protocol string) error {
+		func(ctx context.Context, id instruments.InstrumentID, url, protocol string) error {
 			_, err := h.is.AddCamera(ctx, instruments.Camera{
 				InstrumentID: id,
 				URL:          url,

--- a/internal/app/pslive/routes/instruments/instrument.go
+++ b/internal/app/pslive/routes/instruments/instrument.go
@@ -19,47 +19,47 @@ import (
 	"github.com/sargassum-world/pslive/internal/clients/presence"
 )
 
-func parseID(raw string, typeName string) (int64, error) {
+func parseID[ID ~int64](raw string, typeName string) (ID, error) {
 	const intBase = 10
 	const intWidth = 64
 	id, err := strconv.ParseInt(raw, intBase, intWidth)
 	if err != nil {
 		return 0, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid %s id", typeName))
 	}
-	return id, err
+	return ID(id), err
 }
 
 // Instrument
 
 type InstrumentViewData struct {
 	Instrument       instruments.Instrument
-	ControllerIDs    []int64
-	Controllers      map[int64]planktoscope.Planktoscope
-	AdminIdentifier  string
+	ControllerIDs    []instruments.ControllerID
+	Controllers      map[instruments.ControllerID]planktoscope.Planktoscope
+	AdminIdentifier  ory.IdentityIdentifier
 	KnownViewers     []presence.User
-	AnonymousViewers []string
+	AnonymousViewers []presence.SessionID
 	ChatMessages     []handling.ChatMessageViewData
 }
 
 func getInstrumentViewData(
-	ctx context.Context, instrumentID int64,
+	ctx context.Context, iid instruments.InstrumentID,
 	oc *ory.Client, is *instruments.Store, pco *planktoscope.Orchestrator,
 	ps *presence.Store, cs *chat.Store,
 ) (vd InstrumentViewData, err error) {
-	if vd.Instrument, err = is.GetInstrument(ctx, instrumentID); err != nil {
+	if vd.Instrument, err = is.GetInstrument(ctx, iid); err != nil {
 		// TODO: is this the best way to handle errors from is.GetInstrumentByID?
 		return InstrumentViewData{}, echo.NewHTTPError(
-			http.StatusNotFound, fmt.Sprintf("instrument %d not found", instrumentID),
+			http.StatusNotFound, fmt.Sprintf("instrument %d not found", iid),
 		)
 	}
 
-	vd.ControllerIDs = make([]int64, 0, len(vd.Instrument.Controllers))
-	vd.Controllers = make(map[int64]planktoscope.Planktoscope)
+	vd.ControllerIDs = make([]instruments.ControllerID, 0, len(vd.Instrument.Controllers))
+	vd.Controllers = make(map[instruments.ControllerID]planktoscope.Planktoscope)
 	for _, controller := range vd.Instrument.Controllers {
-		pc, ok := pco.Get(controller.ID)
+		pc, ok := pco.Get(planktoscope.ClientID(controller.ID))
 		if !ok {
 			return InstrumentViewData{}, errors.Errorf(
-				"planktoscope client for instrument %d not found", instrumentID,
+				"planktoscope client for instrument %d not found", iid,
 			)
 		}
 		if pc.HasConnection() {
@@ -70,26 +70,30 @@ func getInstrumentViewData(
 		}
 	}
 
-	if vd.AdminIdentifier, err = oc.GetIdentifier(ctx, vd.Instrument.AdminID); err != nil {
+	if vd.AdminIdentifier, err = oc.GetIdentifier(
+		ctx, ory.IdentityID(vd.Instrument.AdminID),
+	); err != nil {
 		return InstrumentViewData{}, errors.Wrapf(
-			err, "couldn't look up admin identifier for instrument %d", instrumentID,
+			err, "couldn't look up admin identifier for instrument %d", iid,
 		)
 	}
 
 	// Chat
-	vd.KnownViewers, vd.AnonymousViewers = ps.List(fmt.Sprintf("/instruments/%d/users", instrumentID))
+	vd.KnownViewers, vd.AnonymousViewers = ps.List(presence.Topic(
+		fmt.Sprintf("/instruments/%d/users", iid)))
 	messages, err := cs.GetMessagesByTopic(
-		ctx, fmt.Sprintf("/instruments/%d/chat/messages", instrumentID), chat.DefaultMessagesLimit,
+		ctx, chat.Topic(fmt.Sprintf("/instruments/%d/chat/messages", iid)),
+		chat.DefaultMessagesLimit,
 	)
 	if err != nil {
 		return InstrumentViewData{}, errors.Wrapf(
-			err, "couldn't get chat messages for instrument %d", instrumentID,
+			err, "couldn't get chat messages for instrument %d", iid,
 		)
 	}
 	vd.ChatMessages, err = handling.AdaptChatMessages(ctx, messages, oc)
 	if err != nil {
 		return InstrumentViewData{}, errors.Wrapf(
-			err, "couldn't adapt chat messages for instrument %d into view data", instrumentID,
+			err, "couldn't adapt chat messages for instrument %d into view data", iid,
 		)
 	}
 
@@ -98,23 +102,23 @@ func getInstrumentViewData(
 
 type InstrumentViewAuthz struct {
 	SendChat    bool
-	Controllers map[int64]interface{}
+	Controllers map[instruments.ControllerID]interface{}
 }
 
 func getInstrumentViewAuthz(
-	ctx context.Context, instrumentID int64, controllerIDs []int64, a auth.Auth,
-	azc *auth.AuthzChecker,
+	ctx context.Context, iid instruments.InstrumentID, controllerIDs []instruments.ControllerID,
+	a auth.Auth, azc *auth.AuthzChecker,
 ) (authz InstrumentViewAuthz, err error) {
 	eg, egctx := errgroup.WithContext(ctx)
 	controllerAuthorizations := make([]interface{}, len(controllerIDs))
 	for i, controllerID := range controllerIDs {
-		eg.Go(func(i int, cid int64) func() error {
+		eg.Go(func(i int, cid instruments.ControllerID) func() error {
 			return func() (err error) {
 				if controllerAuthorizations[i], err = getPlanktoscopeControllerViewAuthz(
-					egctx, instrumentID, cid, a, azc,
+					egctx, iid, cid, a, azc,
 				); err != nil {
 					return errors.Wrapf(
-						err, "couldn't check authz for controller %d for instrument %d", cid, instrumentID,
+						err, "couldn't check authz for controller %d for instrument %d", cid, iid,
 					)
 				}
 				return nil
@@ -122,10 +126,10 @@ func getInstrumentViewAuthz(
 		}(i, controllerID))
 	}
 	eg.Go(func() (err error) {
-		path := fmt.Sprintf("/instruments/%d/chat/messages", instrumentID)
+		path := fmt.Sprintf("/instruments/%d/chat/messages", iid)
 		if authz.SendChat, err = azc.Allow(egctx, a, path, http.MethodPost, nil); err != nil {
 			return errors.Wrapf(
-				err, "couldn't check authz for sending to chat for instrument %d", instrumentID,
+				err, "couldn't check authz for sending to chat for instrument %d", iid,
 			)
 		}
 		return nil
@@ -133,7 +137,7 @@ func getInstrumentViewAuthz(
 	if err := eg.Wait(); err != nil {
 		return InstrumentViewAuthz{}, err
 	}
-	authz.Controllers = make(map[int64]interface{})
+	authz.Controllers = make(map[instruments.ControllerID]interface{})
 	for i, controllerID := range controllerIDs {
 		authz.Controllers[controllerID] = controllerAuthorizations[i]
 	}
@@ -145,21 +149,19 @@ func (h *Handlers) HandleInstrumentGet() auth.HTTPHandlerFunc {
 	h.r.MustHave(t)
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
 
 		// Run queries
 		ctx := c.Request().Context()
-		instrumentViewData, err := getInstrumentViewData(
-			ctx, instrumentID, h.oc, h.is, h.pco, h.ps, h.cs,
-		)
+		instrumentViewData, err := getInstrumentViewData(ctx, iid, h.oc, h.is, h.pco, h.ps, h.cs)
 		if err != nil {
 			return err
 		}
 		if a.Authorizations, err = getInstrumentViewAuthz(
-			ctx, instrumentID, instrumentViewData.ControllerIDs, a, h.azc,
+			ctx, iid, instrumentViewData.ControllerIDs, a, h.azc,
 		); err != nil {
 			return err
 		}
@@ -172,7 +174,7 @@ func (h *Handlers) HandleInstrumentGet() auth.HTTPHandlerFunc {
 func (h *Handlers) HandleInstrumentPost() auth.HTTPHandlerFunc {
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
@@ -189,7 +191,7 @@ func (h *Handlers) HandleInstrumentPost() auth.HTTPHandlerFunc {
 			// FIXME: there needs to be an authorization check to ensure that the user attempting to
 			// delete the instrument is an administrator of the instrument!
 
-			if err = h.is.DeleteInstrument(ctx, instrumentID); err != nil {
+			if err = h.is.DeleteInstrument(ctx, iid); err != nil {
 				return err
 			}
 			// TODO: cancel any relevant turbo streams topics
@@ -203,7 +205,7 @@ func (h *Handlers) HandleInstrumentPost() auth.HTTPHandlerFunc {
 func (h *Handlers) HandleInstrumentNamePost() auth.HTTPHandlerFunc {
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
@@ -212,21 +214,21 @@ func (h *Handlers) HandleInstrumentNamePost() auth.HTTPHandlerFunc {
 		// Run queries
 		// FIXME: there needs to be an authorization check to ensure that the user attempting to
 		// delete the instrument is an administrator of the instrument!
-		if err := h.is.UpdateInstrumentName(c.Request().Context(), instrumentID, name); err != nil {
+		if err := h.is.UpdateInstrumentName(c.Request().Context(), iid, name); err != nil {
 			return err
 		}
 
 		// TODO: return turbo stream, broadcast updates
 
 		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", instrumentID))
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
 }
 
 func (h *Handlers) HandleInstrumentDescriptionPost() auth.HTTPHandlerFunc {
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
@@ -236,7 +238,7 @@ func (h *Handlers) HandleInstrumentDescriptionPost() auth.HTTPHandlerFunc {
 		// FIXME: there needs to be an authorization check to ensure that the user attempting to
 		// delete the instrument is an administrator of the instrument!
 		if err := h.is.UpdateInstrumentDescription(
-			c.Request().Context(), instrumentID, description,
+			c.Request().Context(), iid, description,
 		); err != nil {
 			return err
 		}
@@ -244,18 +246,18 @@ func (h *Handlers) HandleInstrumentDescriptionPost() auth.HTTPHandlerFunc {
 		// TODO: return turbo stream, broadcast updates
 
 		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", instrumentID))
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
 }
 
 // Components
 
 func handleInstrumentComponentsPost(
-	storeAdder func(ctx context.Context, instrumentID int64, url, protocol string) error,
+	storeAdder func(ctx context.Context, iid instruments.InstrumentID, url, protocol string) error,
 ) auth.HTTPHandlerFunc {
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
@@ -265,29 +267,29 @@ func handleInstrumentComponentsPost(
 		// Run queries
 		// FIXME: there needs to be an authorization check to ensure that the user attempting to
 		// delete the instrument is an administrator of the instrument!
-		if err := storeAdder(c.Request().Context(), instrumentID, url, protocol); err != nil {
+		if err := storeAdder(c.Request().Context(), iid, url, protocol); err != nil {
 			return err
 		}
 
 		// TODO: return turbo stream, broadcast updates
 
 		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", instrumentID))
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
 }
 
-func handleInstrumentComponentPost(
+func handleInstrumentComponentPost[ComponentID ~int64](
 	typeName string,
-	componentUpdater func(ctx context.Context, componentID int64, url, protocol string) error,
-	componentDeleter func(ctx context.Context, componentID int64) error,
+	componentUpdater func(ctx context.Context, componentID ComponentID, url, protocol string) error,
+	componentDeleter func(ctx context.Context, componentID ComponentID) error,
 ) auth.HTTPHandlerFunc {
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
-		componentID, err := parseID(c.Param(typeName+"ID"), typeName)
+		componentID, err := parseID[ComponentID](c.Param(typeName+"ID"), typeName)
 		if err != nil {
 			return err
 		}
@@ -317,7 +319,7 @@ func handleInstrumentComponentPost(
 		}
 
 		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", instrumentID))
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
 }
 
@@ -325,16 +327,16 @@ func handleInstrumentComponentPost(
 
 func (h *Handlers) HandleInstrumentControllersPost() auth.HTTPHandlerFunc {
 	return handleInstrumentComponentsPost(
-		func(ctx context.Context, instrumentID int64, url, protocol string) error {
+		func(ctx context.Context, iid instruments.InstrumentID, url, protocol string) error {
 			controllerID, err := h.is.AddController(ctx, instruments.Controller{
-				InstrumentID: instrumentID,
+				InstrumentID: iid,
 				URL:          url,
 				Protocol:     protocol,
 			})
 			if err != nil {
 				return err
 			}
-			if err := h.pco.Add(controllerID, url); err != nil {
+			if err := h.pco.Add(planktoscope.ClientID(controllerID), url); err != nil {
 				return err
 			}
 			return nil
@@ -345,24 +347,25 @@ func (h *Handlers) HandleInstrumentControllersPost() auth.HTTPHandlerFunc {
 func (h *Handlers) HandleInstrumentControllerPost() auth.HTTPHandlerFunc {
 	return handleInstrumentComponentPost(
 		"controller",
-		func(ctx context.Context, componentID int64, url, protocol string) error {
+		func(ctx context.Context, controllerID instruments.ControllerID, url, protocol string) error {
 			if err := h.is.UpdateController(ctx, instruments.Controller{
-				ID:       componentID,
+				ID:       controllerID,
 				URL:      url,
 				Protocol: protocol,
 			}); err != nil {
 				return err
 			}
-			if err := h.pco.Update(ctx, componentID, url); err != nil {
+			// Note: when we have other controllers, we'll need to generalize this
+			if err := h.pco.Update(ctx, planktoscope.ClientID(controllerID), url); err != nil {
 				return err
 			}
 			return nil
 		},
-		func(ctx context.Context, componentID int64) error {
-			if err := h.is.DeleteController(ctx, componentID); err != nil {
+		func(ctx context.Context, controllerID instruments.ControllerID) error {
+			if err := h.is.DeleteController(ctx, controllerID); err != nil {
 				return err
 			}
-			if err := h.pco.Remove(ctx, componentID); err != nil {
+			if err := h.pco.Remove(ctx, planktoscope.ClientID(controllerID)); err != nil {
 				return err
 			}
 			return nil

--- a/internal/app/pslive/routes/instruments/instruments.go
+++ b/internal/app/pslive/routes/instruments/instruments.go
@@ -16,7 +16,7 @@ import (
 
 type InstrumentsViewData struct {
 	Instruments      []instruments.Instrument
-	AdminIdentifiers map[string]string
+	AdminIdentifiers map[instruments.AdminID]ory.IdentityIdentifier
 }
 
 func getInstrumentsViewData(
@@ -26,10 +26,10 @@ func getInstrumentsViewData(
 		return InstrumentsViewData{}, err
 	}
 
-	vd.AdminIdentifiers = make(map[string]string)
+	vd.AdminIdentifiers = make(map[instruments.AdminID]ory.IdentityIdentifier)
 	for _, instrument := range vd.Instruments {
 		if vd.AdminIdentifiers[instrument.AdminID], err = oc.GetIdentifier(
-			ctx, instrument.AdminID,
+			ctx, ory.IdentityID(instrument.AdminID),
 		); err != nil {
 			// TODO: log the error
 			continue
@@ -78,7 +78,7 @@ func (h *Handlers) HandleInstrumentsPost() auth.HTTPHandlerFunc {
 		i := instruments.Instrument{
 			Name:        haikunator.New().Haikunate(),
 			Description: "An unknown instrument!",
-			AdminID:     a.Identity.User,
+			AdminID:     instruments.AdminID(a.Identity.User),
 		}
 		id, err := h.is.AddInstrument(c.Request().Context(), i)
 		if err != nil {

--- a/internal/app/pslive/routes/instruments/planktoscope.go
+++ b/internal/app/pslive/routes/instruments/planktoscope.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
 	"github.com/sargassum-world/pslive/internal/app/pslive/handling"
+	"github.com/sargassum-world/pslive/internal/clients/instruments"
 	"github.com/sargassum-world/pslive/internal/clients/planktoscope"
 )
 
@@ -22,16 +23,17 @@ import (
 const pumpPartial = "instruments/planktoscope/pump.partial.tmpl"
 
 func replacePumpStream(
-	instrumentID, controllerID int64, a auth.Auth, pc *planktoscope.Client,
+	iid instruments.InstrumentID, cid instruments.ControllerID, a auth.Auth,
+	pc *planktoscope.Client,
 ) turbostreams.Message {
 	state := pc.GetState()
 	return turbostreams.Message{
 		Action:   turbostreams.ActionReplace,
-		Target:   fmt.Sprintf("/instruments/%d/controllers/%d/pump", instrumentID, controllerID),
+		Target:   fmt.Sprintf("/instruments/%d/controllers/%d/pump", iid, cid),
 		Template: pumpPartial,
 		Data: map[string]interface{}{
-			"InstrumentID": instrumentID,
-			"ControllerID": controllerID,
+			"InstrumentID": iid,
+			"ControllerID": cid,
 			"PumpSettings": state.PumpSettings,
 			"Pump":         state.Pump,
 			"Auth":         a,
@@ -81,7 +83,7 @@ func (h *Handlers) HandlePumpPub() turbostreams.HandlerFunc {
 	h.r.MustHave(t)
 	return func(c *turbostreams.Context) error {
 		// Parse params & run queries
-		instrumentID, controllerID, pc, err := getPlanktoscopeClientForPub(c, h.pco)
+		iid, cid, pc, err := getPlanktoscopeClientForPub(c, h.pco)
 		if err != nil {
 			return err
 		}
@@ -99,7 +101,7 @@ func (h *Handlers) HandlePumpPub() turbostreams.HandlerFunc {
 				}
 				// We insert an empty Auth object because the MSG handler will add the auth object for each
 				// client
-				message := replacePumpStream(instrumentID, controllerID, auth.Auth{}, pc)
+				message := replacePumpStream(iid, cid, auth.Auth{}, pc)
 				c.Publish(message)
 			}
 		}
@@ -111,9 +113,10 @@ type PlanktoscopePumpViewAuthz struct {
 }
 
 func getPlanktoscopePumpViewAuthz(
-	ctx context.Context, instrumentID, controllerID int64, a auth.Auth, azc *auth.AuthzChecker,
+	ctx context.Context, iid instruments.InstrumentID, cid instruments.ControllerID,
+	a auth.Auth, azc *auth.AuthzChecker,
 ) (authz PlanktoscopePumpViewAuthz, err error) {
-	path := fmt.Sprintf("/instruments/%d/controllers/%d/pump", instrumentID, controllerID)
+	path := fmt.Sprintf("/instruments/%d/controllers/%d/pump", iid, cid)
 	if authz.Set, err = azc.Allow(ctx, a, path, http.MethodPost, nil); err != nil {
 		return PlanktoscopePumpViewAuthz{}, errors.Wrap(err, "couldn't check authz for setting pump")
 	}
@@ -124,17 +127,16 @@ func (h *Handlers) ModifyPumpMsgData() handling.DataModifier {
 	return func(
 		ctx context.Context, a auth.Auth, data map[string]interface{},
 	) (modifications map[string]interface{}, err error) {
-		instrumentID, controllerID, err := getIDsForModificationMiddleware(data)
+		iid, cid, err := getIDsForModificationMiddleware(data)
 		if err != nil {
 			return nil, err
 		}
 		modifications = make(map[string]interface{})
 		if modifications["Authorizations"], err = getPlanktoscopePumpViewAuthz(
-			ctx, instrumentID, controllerID, a, h.azc,
+			ctx, iid, cid, a, h.azc,
 		); err != nil {
 			return nil, errors.Wrapf(
-				err, "couldn't check authz for pump of controller %d of instrument %d",
-				controllerID, instrumentID,
+				err, "couldn't check authz for pump of controller %d of instrument %d", cid, iid,
 			)
 		}
 		return modifications, nil
@@ -146,21 +148,20 @@ func (h *Handlers) HandlePumpPost() auth.HTTPHandlerFunc {
 	h.r.MustHave(t)
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
-		controllerID, err := parseID(c.Param("controllerID"), "controller")
+		cid, err := parseID[instruments.ControllerID](c.Param("controllerID"), "controller")
 		if err != nil {
 			return err
 		}
 
 		// Run queries
-		pc, ok := h.pco.Get(controllerID)
+		pc, ok := h.pco.Get(planktoscope.ClientID(cid))
 		if !ok {
 			return errors.Errorf(
-				"planktoscope client for controller %d on instrument %d not found for pump post",
-				controllerID, instrumentID,
+				"planktoscope client for controller %d on instrument %d not found for pump post", cid, iid,
 			)
 		}
 		if err = handlePumpSettings(
@@ -180,7 +181,7 @@ func (h *Handlers) HandlePumpPost() auth.HTTPHandlerFunc {
 		}
 
 		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", instrumentID))
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
 }
 
@@ -189,16 +190,17 @@ func (h *Handlers) HandlePumpPost() auth.HTTPHandlerFunc {
 const cameraPartial = "instruments/planktoscope/camera.partial.tmpl"
 
 func replaceCameraStream(
-	instrumentID, controllerID int64, a auth.Auth, pc *planktoscope.Client,
+	iid instruments.InstrumentID, cid instruments.ControllerID, a auth.Auth,
+	pc *planktoscope.Client,
 ) turbostreams.Message {
 	state := pc.GetState()
 	return turbostreams.Message{
 		Action:   turbostreams.ActionReplace,
-		Target:   fmt.Sprintf("/instruments/%d/controllers/%d/camera", instrumentID, controllerID),
+		Target:   fmt.Sprintf("/instruments/%d/controllers/%d/camera", iid, cid),
 		Template: cameraPartial,
 		Data: map[string]interface{}{
-			"InstrumentID":   instrumentID,
-			"ControllerID":   controllerID,
+			"InstrumentID":   iid,
+			"ControllerID":   cid,
 			"CameraSettings": state.CameraSettings,
 			"Auth":           a,
 		},
@@ -260,7 +262,7 @@ func (h *Handlers) HandleCameraPub() turbostreams.HandlerFunc {
 	h.r.MustHave(t)
 	return func(c *turbostreams.Context) error {
 		// Parse params & run queries
-		instrumentID, controllerID, pc, err := getPlanktoscopeClientForPub(c, h.pco)
+		iid, cid, pc, err := getPlanktoscopeClientForPub(c, h.pco)
 		if err != nil {
 			return err
 		}
@@ -278,7 +280,7 @@ func (h *Handlers) HandleCameraPub() turbostreams.HandlerFunc {
 				}
 				// We insert an empty Auth object because the MSG handler will add the auth object for each
 				// client
-				message := replaceCameraStream(instrumentID, controllerID, auth.Auth{}, pc)
+				message := replaceCameraStream(iid, cid, auth.Auth{}, pc)
 				c.Publish(message)
 			}
 		}
@@ -290,9 +292,10 @@ type PlanktoscopeCameraViewAuthz struct {
 }
 
 func getPlanktoscopeCameraViewAuthz(
-	ctx context.Context, instrumentID, controllerID int64, a auth.Auth, azc *auth.AuthzChecker,
+	ctx context.Context, iid instruments.InstrumentID, cid instruments.ControllerID,
+	a auth.Auth, azc *auth.AuthzChecker,
 ) (authz PlanktoscopeCameraViewAuthz, err error) {
-	path := fmt.Sprintf("/instruments/%d/controllers/%d/camera", instrumentID, controllerID)
+	path := fmt.Sprintf("/instruments/%d/controllers/%d/camera", iid, cid)
 	if authz.Set, err = azc.Allow(ctx, a, path, http.MethodPost, nil); err != nil {
 		return PlanktoscopeCameraViewAuthz{}, errors.Wrap(
 			err, "couldn't check authz for setting camera",
@@ -305,17 +308,16 @@ func (h *Handlers) ModifyCameraMsgData() handling.DataModifier {
 	return func(
 		ctx context.Context, a auth.Auth, data map[string]interface{},
 	) (modifications map[string]interface{}, err error) {
-		instrumentID, controllerID, err := getIDsForModificationMiddleware(data)
+		iid, cid, err := getIDsForModificationMiddleware(data)
 		if err != nil {
 			return nil, err
 		}
 		modifications = make(map[string]interface{})
 		if modifications["Authorizations"], err = getPlanktoscopeCameraViewAuthz(
-			ctx, instrumentID, controllerID, a, h.azc,
+			ctx, iid, cid, a, h.azc,
 		); err != nil {
 			return nil, errors.Wrapf(
-				err, "couldn't check authz for camera of controller %d of instrument %d",
-				controllerID, instrumentID,
+				err, "couldn't check authz for camera of controller %d of instrument %d", cid, iid,
 			)
 		}
 		return modifications, nil
@@ -327,21 +329,21 @@ func (h *Handlers) HandleCameraPost() auth.HTTPHandlerFunc {
 	h.r.MustHave(t)
 	return func(c echo.Context, a auth.Auth) error {
 		// Parse params
-		instrumentID, err := parseID(c.Param("id"), "instrument")
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 		if err != nil {
 			return err
 		}
-		controllerID, err := parseID(c.Param("controllerID"), "controller")
+		cid, err := parseID[instruments.ControllerID](c.Param("controllerID"), "controller")
 		if err != nil {
 			return err
 		}
 
 		// Run queries
-		pc, ok := h.pco.Get(controllerID)
+		pc, ok := h.pco.Get(planktoscope.ClientID(cid))
 		if !ok {
 			return errors.Errorf(
 				"planktoscope client for controller %d on instrument %d not found for camera post",
-				controllerID, instrumentID,
+				cid, iid,
 			)
 		}
 		if err = handleCameraSettings(
@@ -361,7 +363,7 @@ func (h *Handlers) HandleCameraPost() auth.HTTPHandlerFunc {
 		}
 
 		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", instrumentID))
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
 }
 
@@ -373,15 +375,16 @@ type PlanktoscopeControllerViewAuthz struct {
 }
 
 func getPlanktoscopeControllerViewAuthz(
-	ctx context.Context, instrumentID, controllerID int64, a auth.Auth, azc *auth.AuthzChecker,
+	ctx context.Context, iid instruments.InstrumentID, cid instruments.ControllerID,
+	a auth.Auth, azc *auth.AuthzChecker,
 ) (authz PlanktoscopeControllerViewAuthz, err error) {
 	if authz.Pump, err = getPlanktoscopePumpViewAuthz(
-		ctx, instrumentID, controllerID, a, azc,
+		ctx, iid, cid, a, azc,
 	); err != nil {
 		return PlanktoscopeControllerViewAuthz{}, errors.Wrap(err, "couldn't check authz for pump")
 	}
 	if authz.Camera, err = getPlanktoscopeCameraViewAuthz(
-		ctx, instrumentID, controllerID, a, azc,
+		ctx, iid, cid, a, azc,
 	); err != nil {
 		return PlanktoscopeControllerViewAuthz{}, errors.Wrap(err, "couldn't check authz for camera")
 	}
@@ -390,57 +393,60 @@ func getPlanktoscopeControllerViewAuthz(
 
 func getIDsForModificationMiddleware(
 	data map[string]interface{},
-) (instrumentID int64, controllerID int64, err error) {
-	rawInstrumentID, ok := data["InstrumentID"]
+) (iid instruments.InstrumentID, cid instruments.ControllerID, err error) {
+	rawIID, ok := data["InstrumentID"]
 	if !ok {
 		return 0, 0, errors.New(
 			"couldn't find instrument id from turbostreams message data to check authorizations",
 		)
 	}
-	instrumentID, ok = rawInstrumentID.(int64)
+	iid, ok = rawIID.(instruments.InstrumentID)
 	if !ok {
 		return 0, 0, errors.Errorf(
 			"instrument id has unexpected type %T in turbostreams message data for checking authorization",
-			rawInstrumentID,
+			rawIID,
 		)
 	}
-	rawControllerID, ok := data["ControllerID"]
+	rawCID, ok := data["ControllerID"]
 	if !ok {
 		return 0, 0, errors.Errorf(
 			"couldn't find controller id for instrument %d from turbostreams message data to check authorizations",
-			instrumentID,
+			iid,
 		)
 	}
-	controllerID, ok = rawControllerID.(int64)
+	cid, ok = rawCID.(instruments.ControllerID)
 	if !ok {
 		return 0, 0, errors.Errorf(
 			"controller id has unexpected type %T in turbostreams message data for checking authorization",
-			rawControllerID,
+			rawCID,
 		)
 	}
-	return instrumentID, controllerID, nil
+	return iid, cid, nil
 }
 
 func getPlanktoscopeClientForPub(
 	c *turbostreams.Context, pco *planktoscope.Orchestrator,
-) (instrumentID int64, controllerID int64, client *planktoscope.Client, err error) {
+) (
+	iid instruments.InstrumentID, cid instruments.ControllerID, client *planktoscope.Client,
+	err error,
+) {
 	// Parse params
-	instrumentID, err = parseID(c.Param("id"), "instrument")
+	iid, err = parseID[instruments.InstrumentID](c.Param("id"), "instrument")
 	if err != nil {
 		return 0, 0, nil, err
 	}
-	controllerID, err = parseID(c.Param("controllerID"), "controller")
+	cid, err = parseID[instruments.ControllerID](c.Param("controllerID"), "controller")
 	if err != nil {
 		return 0, 0, nil, err
 	}
 
 	// Run queries
-	pc, ok := pco.Get(controllerID)
+	pc, ok := pco.Get(planktoscope.ClientID(cid))
 	if !ok {
 		return 0, 0, nil, errors.Errorf(
 			"planktoscope client for controller %d on instrument %d not found for pub",
-			controllerID, instrumentID,
+			cid, iid,
 		)
 	}
-	return instrumentID, controllerID, pc, nil
+	return iid, cid, pc, nil
 }

--- a/internal/app/pslive/workers/planktoscope.go
+++ b/internal/app/pslive/workers/planktoscope.go
@@ -18,7 +18,7 @@ func EstablishPlanktoscopeControllerConnections(
 		return errors.Wrap(err, "couldn't determine which planktoscope controllers to connect to")
 	}
 	for _, client := range initialClients {
-		if err := pco.Add(client.ID, client.URL); err != nil {
+		if err := pco.Add(planktoscope.ClientID(client.ID), client.URL); err != nil {
 			return err
 		}
 	}

--- a/internal/clients/chat/models.go
+++ b/internal/clients/chat/models.go
@@ -6,13 +6,19 @@ import (
 	"zombiezen.com/go/sqlite"
 )
 
+type (
+	MessageID int64
+	SenderID  string
+	Topic     string
+)
+
 // Message
 
 type Message struct {
-	ID       int64
-	Topic    string
+	ID       MessageID
+	Topic    Topic
 	SendTime time.Time
-	SenderID string
+	SenderID SenderID
 	Body     string
 }
 
@@ -27,7 +33,7 @@ func (m Message) newInsertion() map[string]interface{} {
 
 // Messages
 
-func newMessagesByTopicSelection(topic string, messagesLimit int64) map[string]interface{} {
+func newMessagesByTopicSelection(topic Topic, messagesLimit int64) map[string]interface{} {
 	return map[string]interface{}{
 		"$topic":      topic,
 		"$rows_limit": messagesLimit,
@@ -46,10 +52,10 @@ func newMessagesSelector() *messagesSelector {
 
 func (sel *messagesSelector) Step(s *sqlite.Stmt) error {
 	m := Message{
-		ID:       s.GetInt64("id"),
-		Topic:    s.GetText("topic"),
+		ID:       MessageID(s.GetInt64("id")),
+		Topic:    Topic(s.GetText("topic")),
 		SendTime: time.UnixMilli(s.GetInt64("send_time")),
-		SenderID: s.GetText("sender_id"),
+		SenderID: SenderID(s.GetText("sender_id")),
 		Body:     s.GetText("body"),
 	}
 	sel.messages = append(sel.messages, m)

--- a/internal/clients/chat/store.go
+++ b/internal/clients/chat/store.go
@@ -24,7 +24,7 @@ func NewStore(db *database.DB) *Store {
 var rawInsertMessageQuery string
 var insertMessageQuery string = strings.TrimSpace(rawInsertMessageQuery)
 
-func (s *Store) AddMessage(ctx context.Context, m Message) (messageID int64, err error) {
+func (s *Store) AddMessage(ctx context.Context, m Message) (messageID MessageID, err error) {
 	rowID, err := s.db.ExecuteInsertionForID(ctx, insertMessageQuery, m.newInsertion())
 	if err != nil {
 		return 0, errors.Wrapf(err, "couldn't add chat message with topic %s", m.Topic)
@@ -32,7 +32,7 @@ func (s *Store) AddMessage(ctx context.Context, m Message) (messageID int64, err
 	// TODO: instead of returning the raw ID, return the frontend-facing ID as a salted SHA-256 hash
 	// of the ID to mitigate the insecure direct object reference vulnerability and avoid leaking
 	// info about instrument creation?
-	return rowID, err
+	return MessageID(rowID), err
 }
 
 //go:embed queries/select-messages-by-topic.sql
@@ -42,7 +42,7 @@ var selectMessagesByTopicQuery string = strings.TrimSpace(rawSelectMessagesByTop
 const DefaultMessagesLimit = 50
 
 func (s *Store) GetMessagesByTopic(
-	ctx context.Context, topic string, messagesLimit int64,
+	ctx context.Context, topic Topic, messagesLimit int64,
 ) (messages []Message, err error) {
 	sel := newMessagesSelector()
 	if err = s.db.ExecuteSelection(

--- a/internal/clients/instruments/store.go
+++ b/internal/clients/instruments/store.go
@@ -52,7 +52,7 @@ func (s *Store) UpdateCamera(ctx context.Context, c Camera) (err error) {
 var rawDeleteCameraQuery string
 var deleteCameraQuery string = strings.TrimSpace(rawDeleteCameraQuery)
 
-func (s *Store) DeleteCamera(ctx context.Context, id int64) (err error) {
+func (s *Store) DeleteCamera(ctx context.Context, id CameraID) (err error) {
 	return errors.Wrapf(
 		s.db.ExecuteDelete(ctx, deleteCameraQuery, Camera{ID: id}.newDelete()),
 		"couldn't delete camera %d", id,
@@ -63,7 +63,7 @@ func (s *Store) DeleteCamera(ctx context.Context, id int64) (err error) {
 var rawSelectCameraQuery string
 var selectCameraQuery string = strings.TrimSpace(rawSelectCameraQuery)
 
-func (s *Store) GetCamera(ctx context.Context, id int64) (i Camera, err error) {
+func (s *Store) GetCamera(ctx context.Context, id CameraID) (i Camera, err error) {
 	sel := newCamerasSelector()
 	if err = s.db.ExecuteSelection(
 		ctx, selectCameraQuery, newCameraSelection(id), sel.Step,
@@ -109,7 +109,7 @@ func (s *Store) UpdateController(ctx context.Context, c Controller) (err error) 
 var rawDeleteControllerQuery string
 var deleteControllerQuery string = strings.TrimSpace(rawDeleteControllerQuery)
 
-func (s *Store) DeleteController(ctx context.Context, id int64) (err error) {
+func (s *Store) DeleteController(ctx context.Context, id ControllerID) (err error) {
 	return errors.Wrapf(
 		s.db.ExecuteDelete(ctx, deleteControllerQuery, Controller{ID: id}.newDelete()),
 		"couldn't delete controller %d", id,
@@ -156,7 +156,9 @@ func (s *Store) AddInstrument(ctx context.Context, i Instrument) (instrumentID i
 var rawUpdateInstrumentNameQuery string
 var updateInstrumentNameQuery string = strings.TrimSpace(rawUpdateInstrumentNameQuery)
 
-func (s *Store) UpdateInstrumentName(ctx context.Context, id int64, name string) (err error) {
+func (s *Store) UpdateInstrumentName(
+	ctx context.Context, id InstrumentID, name string,
+) (err error) {
 	return errors.Wrapf(
 		s.db.ExecuteUpdate(ctx, updateInstrumentNameQuery, Instrument{
 			ID:   id,
@@ -171,7 +173,7 @@ var rawUpdateInstrumentDescriptionQuery string
 var updateInstrumentDescriptionQuery string = strings.TrimSpace(rawUpdateInstrumentDescriptionQuery)
 
 func (s *Store) UpdateInstrumentDescription(
-	ctx context.Context, id int64, description string,
+	ctx context.Context, id InstrumentID, description string,
 ) (err error) {
 	return errors.Wrapf(
 		s.db.ExecuteUpdate(ctx, updateInstrumentDescriptionQuery, Instrument{
@@ -186,7 +188,7 @@ func (s *Store) UpdateInstrumentDescription(
 var rawDeleteInstrumentQuery string
 var deleteInstrumentQuery string = strings.TrimSpace(rawDeleteInstrumentQuery)
 
-func (s *Store) DeleteInstrument(ctx context.Context, id int64) (err error) {
+func (s *Store) DeleteInstrument(ctx context.Context, id InstrumentID) (err error) {
 	return errors.Wrapf(
 		s.db.ExecuteDelete(ctx, deleteInstrumentQuery, Instrument{ID: id}.newDelete()),
 		"couldn't delete instrument %d", id,
@@ -197,7 +199,7 @@ func (s *Store) DeleteInstrument(ctx context.Context, id int64) (err error) {
 var rawSelectInstrumentQuery string
 var selectInstrumentQuery string = strings.TrimSpace(rawSelectInstrumentQuery)
 
-func (s *Store) GetInstrument(ctx context.Context, id int64) (i Instrument, err error) {
+func (s *Store) GetInstrument(ctx context.Context, id InstrumentID) (i Instrument, err error) {
 	sel := newInstrumentsSelector()
 	if err = s.db.ExecuteSelection(
 		ctx, selectInstrumentQuery, newInstrumentSelection(id), sel.Step,
@@ -232,7 +234,7 @@ var rawSelectInstrumentsByAdminIDQuery string
 var selectInstrumentsByAdminIDQuery string = strings.TrimSpace(rawSelectInstrumentsByAdminIDQuery)
 
 func (s *Store) GetInstrumentsByAdminID(
-	ctx context.Context, adminID string,
+	ctx context.Context, adminID AdminID,
 ) (instruments []Instrument, err error) {
 	sel := newInstrumentsSelector()
 	if err = s.db.ExecuteSelection(

--- a/internal/clients/ory/cache.go
+++ b/internal/clients/ory/cache.go
@@ -12,23 +12,23 @@ type Cache struct {
 
 // /ory/identities/:id/identifier
 
-func keyIdentifierByID(id string) string {
+func keyIdentifierByID(id IdentityID) string {
 	return fmt.Sprintf("/ory/identities/s:[%s]/identifier", id)
 }
 
 func (c *Cache) SetIdentifierByID(
-	id string, identifier string, costWeight float32,
+	id IdentityID, identifier IdentityIdentifier, costWeight float32,
 ) error {
 	key := keyIdentifierByID(id)
 	return c.Cache.SetEntry(key, identifier, costWeight, -1)
 }
 
-func (c *Cache) UnsetIdentifierByID(id string) {
+func (c *Cache) UnsetIdentifierByID(id IdentityID) {
 	key := keyIdentifierByID(id)
 	c.Cache.UnsetEntry(key)
 }
 
-func (c *Cache) GetIdentifierByID(id string) (string, bool, error) {
+func (c *Cache) GetIdentifierByID(id IdentityID) (IdentityIdentifier, bool, error) {
 	key := keyIdentifierByID(id)
 	var value string
 	keyExists, valueExists, err := c.Cache.GetEntry(key, &value)
@@ -36,5 +36,5 @@ func (c *Cache) GetIdentifierByID(id string) (string, bool, error) {
 		return "", keyExists, err
 	}
 
-	return value, true, nil
+	return IdentityIdentifier(value), true, nil
 }


### PR DESCRIPTION
This PR fixes #217 by correcting the erroneous use of instrument IDs to look up Planktoscope clients in the orchestrator, which actually indexes them by controller ID. Additionally, this PR refactors all internal clients to use "little types" (as described in https://www.jerf.org/iri/post/2945/) for IDs, so that each distinct ID has its own type (still with `string` or `int64` as the underlying type) which will be checked by the compiler.