### PR TITLE
Add toggles to disable instrument camera/controller

### DIFF
--- a/db/embeds.go
+++ b/db/embeds.go
@@ -31,6 +31,7 @@ var MigrationFiles []database.MigrationFile = []database.MigrationFile{
 	{Domain: "instruments", File: instruments.MigrationFiles[1]},
 	{Domain: "instruments", File: instruments.MigrationFiles[2]},
 	{Domain: "sessions", File: sessions.MigrationFiles[0]},
+	{Domain: "instruments", File: instruments.MigrationFiles[3]},
 }
 
 // Queries

--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -206,7 +206,7 @@ func (h *Handlers) HandleInstrumentCameraStreamGet() echo.HandlerFunc {
 		if err != nil {
 			return err
 		}
-		annotated := c.QueryParam("annotated") == "true"
+		annotated := c.QueryParam("annotated") == flagChecked
 		// TODO: implement a max framerate
 
 		// Run queries

--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -129,11 +129,14 @@ func externalSourceFrameSender(
 func (h *Handlers) HandleInstrumentCameraPost() auth.HTTPHandlerFunc {
 	return handleInstrumentComponentPost(
 		"camera",
-		func(ctx context.Context, componentID instruments.CameraID, url, protocol string) error {
+		func(
+			ctx context.Context, componentID instruments.CameraID, url, protocol string, enabled bool,
+		) error {
 			return h.is.UpdateCamera(ctx, instruments.Camera{
 				ID:       componentID,
 				URL:      url,
 				Protocol: protocol,
+				Enabled:  enabled,
 			})
 		},
 		h.is.DeleteCamera,

--- a/internal/app/pslive/routes/instruments/camera.go
+++ b/internal/app/pslive/routes/instruments/camera.go
@@ -77,7 +77,10 @@ func newErrorJPEG(width, height int, message string) []byte {
 	return frame.Im
 }
 
-var jpegError = newErrorJPEG(errorWidth, errorHeight, "stream failed")
+var (
+	frameError = newErrorFrame(errorWidth, errorHeight, "stream failed")
+	jpegError  = newErrorJPEG(errorWidth, errorHeight, "stream failed")
+)
 
 // Sending helpers
 
@@ -295,6 +298,7 @@ func (h *Handlers) HandleInstrumentCameraStreamPub() videostreams.HandlerFunc {
 			}),
 			context.Canceled,
 		); err != nil {
+			c.Publish(frameError)
 			c.Logger().Error(errors.Wrapf(err, "failed to proxy stream %s", sourceURL))
 		}
 		return nil

--- a/internal/app/pslive/routes/instruments/cameras.go
+++ b/internal/app/pslive/routes/instruments/cameras.go
@@ -9,11 +9,14 @@ import (
 
 func (h *Handlers) HandleInstrumentCamerasPost() auth.HTTPHandlerFunc {
 	return handleInstrumentComponentsPost(
-		func(ctx context.Context, id instruments.InstrumentID, url, protocol string) error {
+		func(
+			ctx context.Context, id instruments.InstrumentID, url, protocol string, enabled bool,
+		) error {
 			_, err := h.is.AddCamera(ctx, instruments.Camera{
 				InstrumentID: id,
 				URL:          url,
 				Protocol:     protocol,
+				Enabled:      enabled,
 			})
 			return err
 		},

--- a/internal/app/pslive/routes/instruments/controller.go
+++ b/internal/app/pslive/routes/instruments/controller.go
@@ -1,0 +1,41 @@
+package instruments
+
+import (
+	"context"
+
+	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
+	"github.com/sargassum-world/pslive/internal/clients/instruments"
+	"github.com/sargassum-world/pslive/internal/clients/planktoscope"
+)
+
+func (h *Handlers) HandleInstrumentControllerPost() auth.HTTPHandlerFunc {
+	return handleInstrumentComponentPost(
+		"controller",
+		func(
+			ctx context.Context, controllerID instruments.ControllerID, url, protocol string, enabled bool,
+		) error {
+			if err := h.is.UpdateController(ctx, instruments.Controller{
+				ID:       controllerID,
+				URL:      url,
+				Protocol: protocol,
+				Enabled:  enabled,
+			}); err != nil {
+				return err
+			}
+			// Note: when we have other controllers, we'll need to generalize this
+			if !enabled {
+				return h.pco.Remove(ctx, planktoscope.ClientID(controllerID))
+			}
+			return h.pco.Update(ctx, planktoscope.ClientID(controllerID), url)
+		},
+		func(ctx context.Context, controllerID instruments.ControllerID) error {
+			if err := h.is.DeleteController(ctx, controllerID); err != nil {
+				return err
+			}
+			if err := h.pco.Remove(ctx, planktoscope.ClientID(controllerID)); err != nil {
+				return err
+			}
+			return nil
+		},
+	)
+}

--- a/internal/app/pslive/routes/instruments/controllers.go
+++ b/internal/app/pslive/routes/instruments/controllers.go
@@ -1,0 +1,31 @@
+package instruments
+
+import (
+	"context"
+
+	"github.com/sargassum-world/pslive/internal/app/pslive/auth"
+	"github.com/sargassum-world/pslive/internal/clients/instruments"
+	"github.com/sargassum-world/pslive/internal/clients/planktoscope"
+)
+
+func (h *Handlers) HandleInstrumentControllersPost() auth.HTTPHandlerFunc {
+	return handleInstrumentComponentsPost(
+		func(
+			ctx context.Context, iid instruments.InstrumentID, url, protocol string, enabled bool,
+		) error {
+			controllerID, err := h.is.AddController(ctx, instruments.Controller{
+				InstrumentID: iid,
+				URL:          url,
+				Protocol:     protocol,
+				Enabled:      enabled,
+			})
+			if err != nil {
+				return err
+			}
+			if !enabled {
+				return nil
+			}
+			return h.pco.Add(planktoscope.ClientID(controllerID), url)
+		},
+	)
+}

--- a/internal/app/pslive/routes/instruments/instrument.go
+++ b/internal/app/pslive/routes/instruments/instrument.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
@@ -27,6 +28,85 @@ func parseID[ID ~int64](raw string, typeName string) (ID, error) {
 		return 0, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid %s id", typeName))
 	}
 	return ID(id), err
+}
+
+// Components (common across cameras & controllers)
+
+func handleInstrumentComponentsPost(
+	storeAdder func(
+		ctx context.Context, iid instruments.InstrumentID, url, protocol string, enabled bool,
+	) error,
+) auth.HTTPHandlerFunc {
+	return func(c echo.Context, a auth.Auth) error {
+		// Parse params
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
+		if err != nil {
+			return err
+		}
+		url := c.FormValue("url")
+		protocol := c.FormValue("protocol")
+		enabled := strings.ToLower(c.FormValue("enabled")) == "true"
+
+		// Run queries
+		// FIXME: there needs to be an authorization check to ensure that the user attempting to
+		// delete the instrument is an administrator of the instrument!
+		if err := storeAdder(c.Request().Context(), iid, url, protocol, enabled); err != nil {
+			return err
+		}
+
+		// TODO: return turbo stream, broadcast updates
+
+		// Redirect user
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
+	}
+}
+
+func handleInstrumentComponentPost[ComponentID ~int64](
+	typeName string,
+	componentUpdater func(
+		ctx context.Context, componentID ComponentID, url, protocol string, enabled bool,
+	) error,
+	componentDeleter func(ctx context.Context, componentID ComponentID) error,
+) auth.HTTPHandlerFunc {
+	return func(c echo.Context, a auth.Auth) error {
+		// Parse params
+		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
+		if err != nil {
+			return err
+		}
+		componentID, err := parseID[ComponentID](c.Param(typeName+"ID"), typeName)
+		if err != nil {
+			return err
+		}
+		state := c.FormValue("state")
+
+		// Run queries
+		ctx := c.Request().Context()
+		switch state {
+		default:
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf(
+				"invalid %s state %s", typeName, state,
+			))
+		case "updated":
+			protocol := c.FormValue("protocol")
+			url := c.FormValue("url")
+			enabled := strings.ToLower(c.FormValue("enabled")) == "true"
+			// FIXME: needs authorization check!
+			if err = componentUpdater(ctx, componentID, url, protocol, enabled); err != nil {
+				return err
+			}
+			// TODO: deal with turbo streams
+		case "deleted":
+			// FIXME: needs authorization check!
+			if err = componentDeleter(ctx, componentID); err != nil {
+				return err
+			}
+			// TODO: deal with turbo streams
+		}
+
+		// Redirect user
+		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
+	}
 }
 
 // Instrument
@@ -56,6 +136,9 @@ func getInstrumentViewData(
 	vd.ControllerIDs = make([]instruments.ControllerID, 0, len(vd.Instrument.Controllers))
 	vd.Controllers = make(map[instruments.ControllerID]planktoscope.Planktoscope)
 	for _, controller := range vd.Instrument.Controllers {
+		if !controller.Enabled {
+			continue
+		}
 		pc, ok := pco.Get(planktoscope.ClientID(controller.ID))
 		if !ok {
 			return InstrumentViewData{}, errors.Errorf(
@@ -248,127 +331,4 @@ func (h *Handlers) HandleInstrumentDescriptionPost() auth.HTTPHandlerFunc {
 		// Redirect user
 		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
 	}
-}
-
-// Components
-
-func handleInstrumentComponentsPost(
-	storeAdder func(ctx context.Context, iid instruments.InstrumentID, url, protocol string) error,
-) auth.HTTPHandlerFunc {
-	return func(c echo.Context, a auth.Auth) error {
-		// Parse params
-		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
-		if err != nil {
-			return err
-		}
-		url := c.FormValue("url")
-		protocol := c.FormValue("protocol")
-
-		// Run queries
-		// FIXME: there needs to be an authorization check to ensure that the user attempting to
-		// delete the instrument is an administrator of the instrument!
-		if err := storeAdder(c.Request().Context(), iid, url, protocol); err != nil {
-			return err
-		}
-
-		// TODO: return turbo stream, broadcast updates
-
-		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
-	}
-}
-
-func handleInstrumentComponentPost[ComponentID ~int64](
-	typeName string,
-	componentUpdater func(ctx context.Context, componentID ComponentID, url, protocol string) error,
-	componentDeleter func(ctx context.Context, componentID ComponentID) error,
-) auth.HTTPHandlerFunc {
-	return func(c echo.Context, a auth.Auth) error {
-		// Parse params
-		iid, err := parseID[instruments.InstrumentID](c.Param("id"), "instrument")
-		if err != nil {
-			return err
-		}
-		componentID, err := parseID[ComponentID](c.Param(typeName+"ID"), typeName)
-		if err != nil {
-			return err
-		}
-		state := c.FormValue("state")
-
-		// Run queries
-		ctx := c.Request().Context()
-		switch state {
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf(
-				"invalid %s state %s", typeName, state,
-			))
-		case "updated":
-			protocol := c.FormValue("protocol")
-			url := c.FormValue("url")
-			// FIXME: needs authorization check!
-			if err = componentUpdater(ctx, componentID, url, protocol); err != nil {
-				return err
-			}
-			// TODO: deal with turbo streams
-		case "deleted":
-			// FIXME: needs authorization check!
-			if err = componentDeleter(ctx, componentID); err != nil {
-				return err
-			}
-			// TODO: deal with turbo streams
-		}
-
-		// Redirect user
-		return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/instruments/%d", iid))
-	}
-}
-
-// Controllers
-
-func (h *Handlers) HandleInstrumentControllersPost() auth.HTTPHandlerFunc {
-	return handleInstrumentComponentsPost(
-		func(ctx context.Context, iid instruments.InstrumentID, url, protocol string) error {
-			controllerID, err := h.is.AddController(ctx, instruments.Controller{
-				InstrumentID: iid,
-				URL:          url,
-				Protocol:     protocol,
-			})
-			if err != nil {
-				return err
-			}
-			if err := h.pco.Add(planktoscope.ClientID(controllerID), url); err != nil {
-				return err
-			}
-			return nil
-		},
-	)
-}
-
-func (h *Handlers) HandleInstrumentControllerPost() auth.HTTPHandlerFunc {
-	return handleInstrumentComponentPost(
-		"controller",
-		func(ctx context.Context, controllerID instruments.ControllerID, url, protocol string) error {
-			if err := h.is.UpdateController(ctx, instruments.Controller{
-				ID:       controllerID,
-				URL:      url,
-				Protocol: protocol,
-			}); err != nil {
-				return err
-			}
-			// Note: when we have other controllers, we'll need to generalize this
-			if err := h.pco.Update(ctx, planktoscope.ClientID(controllerID), url); err != nil {
-				return err
-			}
-			return nil
-		},
-		func(ctx context.Context, controllerID instruments.ControllerID) error {
-			if err := h.is.DeleteController(ctx, controllerID); err != nil {
-				return err
-			}
-			if err := h.pco.Remove(ctx, planktoscope.ClientID(controllerID)); err != nil {
-				return err
-			}
-			return nil
-		},
-	)
 }

--- a/internal/app/pslive/routes/instruments/instrument.go
+++ b/internal/app/pslive/routes/instruments/instrument.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sargassum-world/pslive/internal/clients/presence"
 )
 
+const flagChecked = "true"
+
 func parseID[ID ~int64](raw string, typeName string) (ID, error) {
 	const intBase = 10
 	const intWidth = 64
@@ -45,7 +47,7 @@ func handleInstrumentComponentsPost(
 		}
 		url := c.FormValue("url")
 		protocol := c.FormValue("protocol")
-		enabled := strings.ToLower(c.FormValue("enabled")) == "true"
+		enabled := strings.ToLower(c.FormValue("enabled")) == flagChecked
 
 		// Run queries
 		// FIXME: there needs to be an authorization check to ensure that the user attempting to
@@ -90,7 +92,7 @@ func handleInstrumentComponentPost[ComponentID ~int64](
 		case "updated":
 			protocol := c.FormValue("protocol")
 			url := c.FormValue("url")
-			enabled := strings.ToLower(c.FormValue("enabled")) == "true"
+			enabled := strings.ToLower(c.FormValue("enabled")) == flagChecked
 			// FIXME: needs authorization check!
 			if err = componentUpdater(ctx, componentID, url, protocol, enabled); err != nil {
 				return err

--- a/internal/app/pslive/routes/instruments/planktoscope.go
+++ b/internal/app/pslive/routes/instruments/planktoscope.go
@@ -227,7 +227,7 @@ func handleCameraSettings(
 	}
 
 	const floatWidth = 64
-	autoWhiteBalance := strings.ToLower(autoWhiteBalanceRaw) == "true"
+	autoWhiteBalance := strings.ToLower(autoWhiteBalanceRaw) == flagChecked
 	whiteBalanceRedGain, err := strconv.ParseFloat(whiteBalanceRedGainRaw, floatWidth)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, errors.Wrap(

--- a/internal/app/pslive/routes/videostreams/proxied.go
+++ b/internal/app/pslive/routes/videostreams/proxied.go
@@ -197,6 +197,9 @@ func (h *Handlers) HandleExternalSourcePub() videostreams.HandlerFunc {
 					c.Logger().Debugf("received eof from %s", source)
 					return true, nil
 				}
+				if errors.Is(err, context.Canceled) {
+					return true, nil
+				}
 				if err != nil {
 					c.Logger().Errorf("couldn't receive mjpeg frame from %s: %s", source, err)
 					return false, errors.Wrap(err, "couldn't read mjpeg frame")

--- a/internal/clients/instruments/embeds.go
+++ b/internal/clients/instruments/embeds.go
@@ -19,6 +19,7 @@ var MigrationFiles []string = []string{
 	"1-initialize-schema-v0.1.7",
 	"2-rename-user-to-identity-v0.1.11",
 	"3-add-camera-controller-index-v0.1.15",
+	"4-add-enabled-flag-v0.3.4",
 }
 
 // Embeds

--- a/internal/clients/instruments/migrations/4-add-enabled-flag-v0.3.4.down.sql
+++ b/internal/clients/instruments/migrations/4-add-enabled-flag-v0.3.4.down.sql
@@ -1,0 +1,9 @@
+-- Camera
+
+alter table instruments_camera
+drop column enabled;
+
+-- Controller
+
+alter table instruments_controller
+drop column enabled;

--- a/internal/clients/instruments/migrations/4-add-enabled-flag-v0.3.4.up.sql
+++ b/internal/clients/instruments/migrations/4-add-enabled-flag-v0.3.4.up.sql
@@ -1,0 +1,15 @@
+-- Camera
+
+alter table instruments_camera
+add enabled integer; -- used as boolean
+
+update instruments_camera
+set enabled = true;
+
+-- Controller
+
+alter table instruments_controller
+add enabled integer; -- used as boolean
+
+update instruments_controller
+set enabled = true;

--- a/internal/clients/instruments/models.go
+++ b/internal/clients/instruments/models.go
@@ -18,6 +18,7 @@ type Camera struct {
 	InstrumentID InstrumentID
 	URL          string
 	Protocol     string
+	Enabled      bool
 }
 
 func (c Camera) newInsertion() map[string]interface{} {
@@ -25,6 +26,7 @@ func (c Camera) newInsertion() map[string]interface{} {
 		"$instrument_id": c.InstrumentID,
 		"$url":           c.URL,
 		"$protocol":      c.Protocol,
+		"$enabled":       c.Enabled,
 	}
 }
 
@@ -33,6 +35,7 @@ func (c Camera) newUpdate() map[string]interface{} {
 		"$id":       c.ID,
 		"$url":      c.URL,
 		"$protocol": c.Protocol,
+		"$enabled":  c.Enabled,
 	}
 }
 
@@ -70,6 +73,7 @@ func (sel *camerasSelector) Step(s *sqlite.Stmt) error {
 			InstrumentID: InstrumentID(s.GetInt64("instrument_id")),
 			URL:          s.GetText("url"),
 			Protocol:     s.GetText("protocol"),
+			Enabled:      s.GetBool("enabled"),
 		}
 		if id != 0 {
 			sel.ids = append(sel.ids, id)
@@ -93,6 +97,7 @@ type Controller struct {
 	InstrumentID InstrumentID
 	URL          string
 	Protocol     string
+	Enabled      bool
 }
 
 func (c Controller) newInsertion() map[string]interface{} {
@@ -100,6 +105,7 @@ func (c Controller) newInsertion() map[string]interface{} {
 		"$instrument_id": c.InstrumentID,
 		"$url":           c.URL,
 		"$protocol":      c.Protocol,
+		"$enabled":       c.Enabled,
 	}
 }
 
@@ -108,6 +114,7 @@ func (c Controller) newUpdate() map[string]interface{} {
 		"$id":       c.ID,
 		"$url":      c.URL,
 		"$protocol": c.Protocol,
+		"$enabled":  c.Enabled,
 	}
 }
 
@@ -145,6 +152,7 @@ func (sel *controllersSelector) Step(s *sqlite.Stmt) error {
 			InstrumentID: InstrumentID(s.GetInt64("instrument_id")),
 			URL:          s.GetText("url"),
 			Protocol:     s.GetText("protocol"),
+			Enabled:      s.GetBool("enabled"),
 		}
 		if id != 0 {
 			sel.ids = append(sel.ids, id)
@@ -253,6 +261,7 @@ func (sel *instrumentsSelector) Step(s *sqlite.Stmt) error {
 		InstrumentID: instrumentID,
 		URL:          s.GetText("camera_url"),
 		Protocol:     s.GetText("camera_protocol"),
+		Enabled:      s.GetBool("camera_enabled"),
 	}
 	if camera != (Camera{
 		ID:           cameraID,
@@ -267,6 +276,7 @@ func (sel *instrumentsSelector) Step(s *sqlite.Stmt) error {
 		InstrumentID: instrumentID,
 		URL:          s.GetText("controller_url"),
 		Protocol:     s.GetText("controller_protocol"),
+		Enabled:      s.GetBool("controller_enabled"),
 	}
 	if controller != (Controller{
 		ID:           controllerID,

--- a/internal/clients/instruments/queries/insert-camera.sql
+++ b/internal/clients/instruments/queries/insert-camera.sql
@@ -1,2 +1,2 @@
-insert into instruments_camera (url, protocol, instrument_id)
-values ($url, $protocol, $instrument_id);
+insert into instruments_camera (url, protocol, instrument_id, enabled)
+values ($url, $protocol, $instrument_id, $enabled);

--- a/internal/clients/instruments/queries/insert-controller.sql
+++ b/internal/clients/instruments/queries/insert-controller.sql
@@ -1,2 +1,2 @@
-insert into instruments_controller (url, protocol, instrument_id)
-values ($url, $protocol, $instrument_id);
+insert into instruments_controller (url, protocol, instrument_id, enabled)
+values ($url, $protocol, $instrument_id, $enabled);

--- a/internal/clients/instruments/queries/select-camera.sql
+++ b/internal/clients/instruments/queries/select-camera.sql
@@ -2,7 +2,8 @@ select
   id            as id,
   instrument_id as instrument_id,
   url           as url,
-  protocol      as protocol
+  protocol      as protocol,
+  enabled       as enabled
 from instruments_camera as c
 where
   c.id = $id

--- a/internal/clients/instruments/queries/select-controllers-by-protocol.sql
+++ b/internal/clients/instruments/queries/select-controllers-by-protocol.sql
@@ -2,7 +2,8 @@ select
   id            as id,
   instrument_id as instrument_id,
   url           as url,
-  protocol      as protocol
+  protocol      as protocol,
+  enabled       as enabled
 from instruments_controller as c
 where
   c.protocol = $protocol

--- a/internal/clients/instruments/queries/select-instrument.sql
+++ b/internal/clients/instruments/queries/select-instrument.sql
@@ -6,9 +6,11 @@ select
   ca.id               as camera_id,
   ca.url              as camera_url,
   ca.protocol         as camera_protocol,
+  ca.enabled          as camera_enabled,
   co.id               as controller_id,
   co.url              as controller_url,
-  co.protocol         as controller_protocol
+  co.protocol         as controller_protocol,
+  co.enabled          as controller_enabled
 from instruments_instrument as i
 left join instruments_camera as ca
   on i.id = ca.instrument_id

--- a/internal/clients/instruments/queries/select-instruments-by-admin-id.sql
+++ b/internal/clients/instruments/queries/select-instruments-by-admin-id.sql
@@ -6,9 +6,11 @@ select
   ca.id               as camera_id,
   ca.url              as camera_url,
   ca.protocol         as camera_protocol,
+  ca.enabled          as camera_enabled,
   co.id               as controller_id,
   co.url              as controller_url,
-  co.protocol         as controller_protocol
+  co.protocol         as controller_protocol,
+  co.enabled          as controller_enabled
 from instruments_instrument as i
 left join instruments_camera as ca
   on i.id = ca.instrument_id

--- a/internal/clients/instruments/queries/select-instruments.sql
+++ b/internal/clients/instruments/queries/select-instruments.sql
@@ -6,9 +6,11 @@ select
   ca.id               as camera_id,
   ca.url              as camera_url,
   ca.protocol         as camera_protocol,
+  ca.enabled          as camera_enabled,
   co.id               as controller_id,
   co.url              as controller_url,
-  co.protocol         as controller_protocol
+  co.protocol         as controller_protocol,
+  co.enabled          as controller_enabled
 from instruments_instrument as i
 left join instruments_camera as ca
   on i.id = ca.instrument_id

--- a/internal/clients/instruments/queries/update-camera.sql
+++ b/internal/clients/instruments/queries/update-camera.sql
@@ -1,5 +1,6 @@
 update instruments_camera
 set
   url = $url,
-  protocol = $protocol
+  protocol = $protocol,
+  enabled = $enabled
 where instruments_camera.id = $id

--- a/internal/clients/instruments/queries/update-controller.sql
+++ b/internal/clients/instruments/queries/update-controller.sql
@@ -1,5 +1,6 @@
 update instruments_controller
 set
   url = $url,
-  protocol = $protocol
+  protocol = $protocol,
+  enabled = $enabled
 where instruments_controller.id = $id

--- a/web/templates/instruments/config/camera.tmpl
+++ b/web/templates/instruments/config/camera.tmpl
@@ -66,6 +66,7 @@
             </div>
           </div>
         </div>
+
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label" for="url">URL</label>
@@ -88,6 +89,30 @@
             </div>
           </div>
         </div>
+
+        <div class="field is-horizontal">
+          <div class="field-label is-normal"><!--Left empty for spacing--></div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <input
+                    type="checkbox"
+                    name="enabled"
+                    value="true"
+                    {{if not $camera}}
+                      checked
+                    {{else if $camera.Enabled}}
+                      checked
+                    {{end}}
+                  >
+                  Enabled
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="field is-horizontal">
           <div class="field-label is-normal"><!--Left empty for spacing--></div>
           <div class="field-body" >

--- a/web/templates/instruments/config/controller.tmpl
+++ b/web/templates/instruments/config/controller.tmpl
@@ -66,6 +66,7 @@
             </div>
           </div>
         </div>
+
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label" for="url">URL</label>
@@ -88,6 +89,30 @@
             </div>
           </div>
         </div>
+
+        <div class="field is-horizontal">
+          <div class="field-label is-normal"><!--Left empty for spacing--></div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <input
+                    type="checkbox"
+                    name="enabled"
+                    value="true"
+                    {{if not $controller}}
+                      checked
+                    {{else if $controller.Enabled}}
+                      checked
+                    {{end}}
+                  >
+                  Enabled
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="field is-horizontal">
           <div class="field-label is-normal"><!--Left empty for spacing--></div>
           <div class="field-body" >

--- a/web/templates/instruments/instrument-live.partial.tmpl
+++ b/web/templates/instruments/instrument-live.partial.tmpl
@@ -9,6 +9,9 @@
 
 <turbo-frame id="/instruments/{{$instrument.ID}}/live">
   {{range $camera := $instrument.Cameras}}
+    {{if not $camera.Enabled}}
+      {{continue}}
+    {{end}}
     <div class="section-card wide-card">
       {{if eq $camera.Protocol "mjpeg"}}
         {{
@@ -55,6 +58,9 @@
     </div>
   </div>
   {{range $controllerID := $controllerIDs}}
+    {{if not (index $instrument.Controllers $controllerID).Enabled}}
+      {{continue}}
+    {{end}}
     {{
       template "instruments/planktoscope/controller.partial.tmpl" dict
       "Instrument" $instrument

--- a/web/templates/shared/instruments/instrument.partial.tmpl
+++ b/web/templates/shared/instruments/instrument.partial.tmpl
@@ -42,15 +42,19 @@
       <div>
         {{$cameraFound := false}}
         {{range $camera := $instrument.Cameras}}
-          {{if not $cameraFound}}
-            <img
-              class="instrument-camera-preview"
-              src="/instruments/{{$instrument.ID}}/cameras/{{$camera.ID}}/frame.jpeg"
-              data-controller="image-autoreload"
-              data-image-autoreload-min-interval-value="5"
-              data-image-autoreload-max-interval-value="15"
-            >
+          {{if $cameraFound}}
+            {{continue}}
           {{end}}
+          {{if not $camera.Enabled}}
+            {{continue}}
+          {{end}}
+          <img
+            class="instrument-camera-preview"
+            src="/instruments/{{$instrument.ID}}/cameras/{{$camera.ID}}/frame.jpeg"
+            data-controller="image-autoreload"
+            data-image-autoreload-min-interval-value="5"
+            data-image-autoreload-max-interval-value="15"
+          >
           {{$cameraFound = true}}
         {{end}}
       <div>


### PR DESCRIPTION
This PR closes #214 by adding a checkbox to the settings card for each instrument camera and controller to set whether it's enabled. A disabled camera is ignored for the UI, while a disabled controller is ignored for the UI and any allocated resources (e.g. an orchestrated Planktoscope MQTT client) are destroyed. This is like deleting a camera or controller, except that the records are still kept in the database for easy reactivation.