### PR TITLE
Build the pslocal Docker image for armv7 rather than amd64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,8 @@ dockers:
     ids:
       - pslocal
     dockerfile: "Dockerfile.pslocal"
+    goarch: arm
+    goarm: 7
     image_templates:
     - "ghcr.io/sargassum-world/pslocal:latest"
     - "ghcr.io/sargassum-world/pslocal:{{ .Major }}"


### PR DESCRIPTION
#255 accidentally built the pslocal Docker image for amd64, which prevented the image from running on armv7 (the architecture used by Raspbian for the Planktoscope). This PR should (hopefully) fix that so that we can actually run the pslocal Docker image on a Raspberry Pi.