### PR TITLE
Build multi-architecture Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,8 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Release test
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Golang with cache
+      - name: Set up Golang with cache
         uses: magnetikonline/action-golang-cache@v4
         with:
           go-version-file: go.mod
 
-      - name: "Docker login"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker login
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,77 +1,211 @@
 before:
   hooks:
     - go mod download
+
 builds:
-- id: "pslive"
+- id: pslive
   main: ./cmd/pslive
   binary: pslive
   env:
     - CGO_ENABLED=0
-  goos:
-    - darwin
-    - linux
-    - windows
-  goarch:
-    - amd64
-- id: "pslocal"
+  targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - linux_arm_7
+    - darwin_amd64_v1
+    - darwin_arm64_v1
+    - windows_amd64_v1
+- id: pslocal
   main: ./cmd/pslocal
   binary: pslocal
   env:
     - CGO_ENABLED=0
-  goos:
-    - linux
-  goarch:
-    - amd64
-    - arm
-  goarm:
-    - 7
+  targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - linux_arm_7
+
 archives:
-  - id: "pslive"
+  - id: pslive
     builds: ["pslive"]
     name_template: "pslive_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
     - goos: windows
       format: zip
-  - id: "pslocal"
+  - id: pslocal
     builds: ["pslocal"]
     name_template: "pslocal_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
 release:
   github:
   prerelease: auto
+
 dockers:
-  -
-    id: pslive
+  # pslive
+  - id: pslive-amd64
     ids:
       - pslive
     dockerfile: "Dockerfile.pslive"
+    use: buildx
     image_templates:
-    - "ghcr.io/sargassum-world/pslive:latest"
-    - "ghcr.io/sargassum-world/pslive:{{ .Major }}"
-    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}"
-    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    - "ghcr.io/sargassum-world/pslive:latest-amd64"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}-amd64"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-amd64"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
     build_flag_templates:
     - "--pull"
+    - "--platform=linux/amd64"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.name={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--label=org.opencontainers.image.source={{.GitURL}}"
-  -
-    id: pslocal
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+  - id: pslive-arm64v8
     ids:
-      - pslocal
-    dockerfile: "Dockerfile.pslocal"
+      - pslive
+    dockerfile: "Dockerfile.pslive"
+    use: buildx
+    goarch: arm64
+    image_templates:
+    - "ghcr.io/sargassum-world/pslive:latest-arm64v8"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm64/v8"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+  - id: pslive-armv7
+    ids:
+      - pslive
+    dockerfile: "Dockerfile.pslive"
+    use: buildx
     goarch: arm
     goarm: 7
     image_templates:
-    - "ghcr.io/sargassum-world/pslocal:latest"
-    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}"
-    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}"
-    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    - "ghcr.io/sargassum-world/pslive:latest-armv7"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}-armv7"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-armv7"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"
     build_flag_templates:
     - "--pull"
+    - "--platform=linux/arm/v7"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.name={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+
+  # pslocal
+  - id: pslocal-amd64
+    ids:
+      - pslocal
+    dockerfile: "Dockerfile.pslocal"
+    use: buildx
+    image_templates:
+    - "ghcr.io/sargassum-world/pslocal:latest-amd64"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-amd64"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-amd64"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/amd64"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+  - id: pslocal-arm64v8
+    ids:
+      - pslocal
+    dockerfile: "Dockerfile.pslocal"
+    use: buildx
+    goarch: arm64
+    image_templates:
+    - "ghcr.io/sargassum-world/pslocal:latest-arm64v8"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm64/v8"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+  - id: pslocal-armv7
+    ids:
+      - pslocal
+    dockerfile: "Dockerfile.pslocal"
+    use: buildx
+    goarch: arm
+    goarm: 7
+    image_templates:
+    - "ghcr.io/sargassum-world/pslocal:latest-armv7"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-armv7"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-armv7"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm/v7"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+
+docker_manifests:
+  # pslive
+  - name_template: "ghcr.io/sargassum-world/pslive:latest"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslive:latest-amd64"
+      - "ghcr.io/sargassum-world/pslive:latest-arm64v8"
+      - "ghcr.io/sargassum-world/pslive:latest-armv7"
+  - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}-amd64"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}-arm64v8"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}-armv7"
+  - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-arm64v8"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-armv7"
+  - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"
+
+  # pslocal
+  - name_template: "ghcr.io/sargassum-world/pslocal:latest"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslocal:latest-amd64"
+      - "ghcr.io/sargassum-world/pslocal:latest-arm64v8"
+      - "ghcr.io/sargassum-world/pslocal:latest-armv7"
+  - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-amd64"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-arm64v8"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-armv7"
+  - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-arm64v8"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-armv7"
+  - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    image_templates:
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,10 @@ builds:
     - CGO_ENABLED=0
   targets:
     - linux_amd64_v1
+    - linux_arm64
     - linux_arm_7
     - darwin_amd64_v1
+    - darwin_arm64
     - windows_amd64_v1
 - id: pslocal
   main: ./cmd/pslocal
@@ -20,6 +22,7 @@ builds:
     - CGO_ENABLED=0
   targets:
     - linux_amd64_v1
+    - linux_arm64
     - linux_arm_7
 
 archives:
@@ -52,6 +55,26 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--platform=linux/amd64"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+  - id: pslive-arm64v8
+    ids:
+      - pslive
+    dockerfile: "Dockerfile.pslive"
+    use: buildx
+    goarch: arm64
+    image_templates:
+    - "ghcr.io/sargassum-world/pslive:latest-arm64v8"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm64/v8"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.name={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -100,6 +123,26 @@ dockers:
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--label=org.opencontainers.image.source={{.GitURL}}"
     - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
+  - id: pslocal-arm64v8
+    ids:
+      - pslocal
+    dockerfile: "Dockerfile.pslocal"
+    use: buildx
+    goarch: arm64
+    image_templates:
+    - "ghcr.io/sargassum-world/pslocal:latest-arm64v8"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-arm64v8"
+    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm64/v8"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
   - id: pslocal-armv7
     ids:
       - pslocal
@@ -127,34 +170,42 @@ docker_manifests:
   - name_template: "ghcr.io/sargassum-world/pslive:latest"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:latest-amd64"
+      - "ghcr.io/sargassum-world/pslive:latest-arm64v8"
       - "ghcr.io/sargassum-world/pslive:latest-armv7"
   - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}-amd64"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}-arm64v8"
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-arm64v8"
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"
 
   # pslocal
   - name_template: "ghcr.io/sargassum-world/pslocal:latest"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:latest-amd64"
+      - "ghcr.io/sargassum-world/pslocal:latest-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:latest-armv7"
   - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-amd64"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,10 +10,8 @@ builds:
     - CGO_ENABLED=0
   targets:
     - linux_amd64_v1
-    - linux_arm64
     - linux_arm_7
     - darwin_amd64_v1
-    - darwin_arm64
     - windows_amd64_v1
 - id: pslocal
   main: ./cmd/pslocal
@@ -22,7 +20,6 @@ builds:
     - CGO_ENABLED=0
   targets:
     - linux_amd64_v1
-    - linux_arm64
     - linux_arm_7
 
 archives:
@@ -55,26 +52,6 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--platform=linux/amd64"
-    - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.name={{.ProjectName}}"
-    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
-    - "--label=org.opencontainers.image.source={{.GitURL}}"
-    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
-  - id: pslive-arm64v8
-    ids:
-      - pslive
-    dockerfile: "Dockerfile.pslive"
-    use: buildx
-    goarch: arm64
-    image_templates:
-    - "ghcr.io/sargassum-world/pslive:latest-arm64v8"
-    - "ghcr.io/sargassum-world/pslive:{{ .Major }}-arm64v8"
-    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-arm64v8"
-    - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
-    build_flag_templates:
-    - "--pull"
-    - "--platform=linux/arm64/v8"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.name={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -123,26 +100,6 @@ dockers:
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--label=org.opencontainers.image.source={{.GitURL}}"
     - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
-  - id: pslocal-arm64v8
-    ids:
-      - pslocal
-    dockerfile: "Dockerfile.pslocal"
-    use: buildx
-    goarch: arm64
-    image_templates:
-    - "ghcr.io/sargassum-world/pslocal:latest-arm64v8"
-    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-arm64v8"
-    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-arm64v8"
-    - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
-    build_flag_templates:
-    - "--pull"
-    - "--platform=linux/arm64/v8"
-    - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.name={{.ProjectName}}"
-    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
-    - "--label=org.opencontainers.image.source={{.GitURL}}"
-    - "--label=org.opencontainers.image.licenses=(Apache-2.0 OR BlueOak-1.0.0)"
   - id: pslocal-armv7
     ids:
       - pslocal
@@ -170,42 +127,34 @@ docker_manifests:
   - name_template: "ghcr.io/sargassum-world/pslive:latest"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:latest-amd64"
-      - "ghcr.io/sargassum-world/pslive:latest-arm64v8"
       - "ghcr.io/sargassum-world/pslive:latest-armv7"
   - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}-amd64"
-      - "ghcr.io/sargassum-world/pslive:{{ .Major }}-arm64v8"
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-arm64v8"
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
-      - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
       - "ghcr.io/sargassum-world/pslive:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"
 
   # pslocal
   - name_template: "ghcr.io/sargassum-world/pslocal:latest"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:latest-amd64"
-      - "ghcr.io/sargassum-world/pslocal:latest-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:latest-armv7"
   - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-amd64"
-      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}-armv7"
   - name_template: "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     image_templates:
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
-      - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
       - "ghcr.io/sargassum-world/pslocal:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     - linux_arm64
     - linux_arm_7
     - darwin_amd64_v1
-    - darwin_arm64_v1
+    - darwin_arm64
     - windows_amd64_v1
 - id: pslocal
   main: ./cmd/pslocal

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to develop on the Rego policies (for authorization & access control)
 
 ### Building
 
-Because the build pipeline builds Docker images, you will need to either have Docker Desktop or (on Ubuntu) to have installed qemu-user-static or have set up tonistiigi/binfmt. You will need a version of Docker with buildx support.
+Because the build pipeline builds Docker images, you will need to either have Docker Desktop or (on Ubuntu) to have installed QEMU (either with qemu-user-static from apt or by running [tonistiigi/binfmt](https://hub.docker.com/r/tonistiigi/binfmt)). You will need a version of Docker with buildx support.
 
 To execute the full build pipeline, run `make`; to build the docker images, run `make build` (make sure you've already run `make install`). Note that `make build` will also automatically regenerate the webapp build artifacts, which means you also need to have first installed Node.js as described in the "Development" section. The resulting built binaries can be found in directories within the dist directory corresponding to OS and CPU architecture (e.g. `./dist/pslive_window_amd64/pslive.exe` or `./dist/pslive_linux_amd64/pslive`)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a multi-user deployment, run the pslive binary with the appropriate environm
 
 ### Development
 
-To install various backend development tools, run `make install`.
+To install various backend development tools, run `make install`. You will need to have installed Go first.
 
 Before you start the server for the first time, you'll need to generate the webapp build artifacts by running `make buildweb` (which requires you to have first installed [Node.js v16](https://nodejs.org/en/) (lts/gallium) and [Yarn Classic](https://classic.yarnpkg.com/lang/en/)). Then you can start the server using golang's `go run` by setting some environment variables and running `make run-live`. You will need to have installed golang first. Any time you modify the webapp files (in the web/app directory), you'll need to run `make buildweb` again to rebuild the bundled CSS and JS. Whenever you use a CSS selector in a template file (in the web/templates directory), you should *also* run `make buildweb`, because the build process for the bundled CSS omits any selectors not used by the templates.
 
@@ -18,7 +18,9 @@ If you want to develop on the Rego policies (for authorization & access control)
 
 ### Building
 
-To execute the full build pipeline, run `make`; to build the docker images, run `make build`. You will need to have installed golang and golangci-lint first; `make build` *should* automatically install golangci-lint, but this might not work; if not, you'll need to install it manually. Note that `make build` will also automatically regenerate the webapp build artifacts. The resulting built binaries can be found in directories within the dist directory corresponding to OS and CPU architecture (e.g. `./dist/pslive_window_amd64/pslive.exe` or `./dist/pslive_linux_amd64/pslive`)
+Because the build pipeline builds Docker images, you will need to either have Docker Desktop or (on Ubuntu) to have installed qemu-user-static or have set up tonistiigi/binfmt. You will need a version of Docker with buildx support.
+
+To execute the full build pipeline, run `make`; to build the docker images, run `make build` (make sure you've already run `make install`). Note that `make build` will also automatically regenerate the webapp build artifacts, which means you also need to have first installed Node.js as described in the "Development" section. The resulting built binaries can be found in directories within the dist directory corresponding to OS and CPU architecture (e.g. `./dist/pslive_window_amd64/pslive.exe` or `./dist/pslive_linux_amd64/pslive`)
 
 ### External Services
 


### PR DESCRIPTION
For some reason, although #256 successfully built a Docker image which I was able to deploy on an ARMv7 Raspberry Pi, when I later tried to pull and re-deploy the same image it appeared to be an amd64 image. This PR attempts to use Docker buildx to do cross-architecture Docker Image builds for multi-architecture images (with AMD64, ARM64, and ARMv7 support). Additionally, Darwin ARM64 is added to the pslive binary build targets while Linux AMD64 and ARM64 are added to the pslocal binary build targets.