### PR TITLE
Allow overriding localhost in default URLs for pslocal

### DIFF
--- a/cmd/pslocal/main.go
+++ b/cmd/pslocal/main.go
@@ -64,13 +64,17 @@ func initializeFromEmpty(ctx context.Context, server *pslive.Server) error {
 	if err != nil {
 		return errors.Wrap(err, "couldn't add default instrument for local planktoscope")
 	}
+	localhost := "localhost"
+	if l := os.Getenv("LOCALHOST_DEFAULT"); l != "" {
+		localhost = l
+	}
 	if _, err = is.AddCamera(ctx, instruments.Camera{
 		InstrumentID: iid,
 		Enabled:      true,
 		Name:         "preview",
 		Description:  "The picamera preview stream",
 		Protocol:     "mjpeg",
-		URL:          "http://localhost:8000",
+		URL:          fmt.Sprintf("http://%s:8000", localhost),
 	}); err != nil {
 		return errors.Wrap(err, "couldn't add default camera for local planktoscope")
 	}
@@ -80,7 +84,7 @@ func initializeFromEmpty(ctx context.Context, server *pslive.Server) error {
 		Name:         "controller",
 		Description:  "The MQTT control API",
 		Protocol:     "planktoscope-v2.3",
-		URL:          "mqtt://localhost:1883",
+		URL:          fmt.Sprintf("mqtt://%s:1883", localhost),
 	}
 	controllerID, err := is.AddController(ctx, controller)
 	if err != nil {


### PR DESCRIPTION
Previously, pslocal assumed that the MQTT API and MJPEG stream were available over `localhost`. However, this assumption only works with pslocal deployments in Docker containers if the containers have host networking mode. This PR adds an environment variable `LOCALHOST_DEFAULT` which can set an alternative hostname instead of `localhost`. This intended for use with [host.docker.internal](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host).